### PR TITLE
#22 - supply_schedule 삭제 controller, service 로직 작성

### DIFF
--- a/src/main/java/com/capstone/pethouse/domain/supply/controller/SupplyController.java
+++ b/src/main/java/com/capstone/pethouse/domain/supply/controller/SupplyController.java
@@ -51,6 +51,15 @@ public class SupplyController {
         return supplyService.toggleSchedule(houseId, scheduleId, enabled);
     }
 
+    // 자동 급수 / 급식 스케줄러 삭제
+    @DeleteMapping("/{houseId}/supplier/schedules/{scheduleId}")
+    public Long deleteSchedule(
+            @PathVariable Long houseId,
+            @PathVariable Long scheduleId
+    ) {
+        return supplyService.deleteSchedule(houseId, scheduleId);
+    }
+
     // 제공된 급식 / 급수에 대한 supply_log 저장 (수동 제공시)
     // 자동 급식 / 급수 제공 시엔 MQTT 리스너가 서비스 호출
     @PostMapping("/{houseId}/supplier/record")

--- a/src/main/java/com/capstone/pethouse/domain/supply/service/SupplyService.java
+++ b/src/main/java/com/capstone/pethouse/domain/supply/service/SupplyService.java
@@ -72,6 +72,15 @@ public class SupplyService {
         return ScheduleToggleResponse.from(supplySchedule);
     }
 
+    public Long deleteSchedule(Long houseId, Long scheduleId) {
+        SupplySchedule supplySchedule = supplyScheduleRepository.findByPetHouse_HouseIdAndId(houseId, scheduleId)
+                .orElseThrow(() -> new EntityNotFoundException("해당 스케줄을 찾을 수 없습니다."));
+
+        supplyScheduleRepository.delete(supplySchedule);
+
+        return supplySchedule.getId();
+    }
+
     public SupplyLogResponse recordSupplyLog(Long houseId, SupplyLogRequest supplyLogRequest) {
         PetHouse petHouse = petHouseRepository.getReferenceById(houseId);
 
@@ -85,6 +94,7 @@ public class SupplyService {
         return SupplyLogResponse.from(supplyLogRepository.save(supplyLog));
     }
 
+    @Transactional(readOnly = true)
     public Page<SupplyLogHistoryResponse> getSupplyHistory(Long houseId, Pageable pageable) {
         Page<SupplyLog> supplyLogsPage = supplyLogRepository.findByPetHouse_HouseId(houseId, pageable);
 


### PR DESCRIPTION
삭제된 schedule의 schedule_id를 반환하도록 설정
추가적으로 read만 하는 getSupplyHistory 메서드에 @Transactional(readOnly = true) 추가