### PR TITLE
feat: TASK-1 MQTT 인프라 구현 (#31)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,273 @@
+# Pet House Monitoring - Backend
+
+## 프로젝트 개요
+반려동물 스마트 하우스 모니터링 시스템의 백엔드 서버.
+IoT 기기(펫하우스)와 MQTT로 통신하며, 센서 데이터 수집, 카메라 스트리밍, 기기 제어를 담당한다.
+
+## 기술 스택
+- Java 21, Spring Boot 3.5.12
+- MySQL 8.0 (JPA + QueryDSL)
+- InfluxDB (센서 시계열 데이터)
+- EMQX (MQTT 브로커)
+- Spring Security + JWT + OAuth2 (카카오/Google/Apple)
+- WebSocket (실시간 센서 푸시)
+- WebRTC / HLS (카메라 스트리밍)
+
+## 패키지 구조
+```
+com.capstone.pethouse
+├── domain
+│   ├── auth/          # JWT, OAuth2, SecurityConfig
+│   ├── device/        # PetHouse CRUD, 프로비저닝
+│   ├── sensor/        # 센서 데이터 수집/조회
+│   ├── camera/        # WebRTC, HLS, PTZ, 녹화
+│   ├── fan/           # 팬 스케줄 (구현 완료)
+│   ├── supply/        # 급식/급수 스케줄 (구현 완료)
+│   └── User/          # 사용자 엔티티
+├── global
+│   ├── config/        # SecurityConfig, MqttConfig, WebSocketConfig 등
+│   ├── common/        # AuditingFields, BaseResponse 등
+│   └── error/         # 예외 처리
+└── infra
+    └── mqtt/          # MqttPublisher, MqttSubscriber, 토픽 관리
+```
+
+## 코드 컨벤션
+- 엔티티: `of()` 정적 팩토리 메서드 사용, `@NoArgsConstructor(access = PROTECTED)`
+- DTO: Request/Response 분리, record 사용 권장
+- API 경로: `/api` prefix는 `server.servlet.context-path`로 이미 설정됨
+- 응답: 일관된 응답 구조 사용
+- 테스트: 서비스 레이어 단위 테스트 필수
+
+## 기존 구현 (이미 완성됨 - 건드리지 말 것)
+- `fan/` - 팬 스케줄 CRUD (FanController, FanService, FanSchedule, FanScheduleDetail, FanLog)
+- `supply/` - 급식/급수 스케줄 CRUD (SupplyController, SupplyService, SupplySchedule, SupplyLog)
+
+---
+
+# 개발자 A 담당 영역 (5개 도메인, 총 44개)
+
+## [TASK-1] MQTT 인프라 (5개) — 모든 IoT 통신의 기반
+우선순위: ★★★★★ (가장 먼저)
+
+### 구현 목표
+EMQX 브로커와 Spring Boot 연동. 서버가 기기에 명령을 보내고(Publish), 기기로부터 데이터를 받는(Subscribe) 기반 인프라.
+
+### 구현 항목
+1. **EMQX Docker 설정** — docker-compose.yml에 EMQX 서비스 추가
+2. **MqttConfig** — Spring Integration MQTT 설정 (InboundAdapter, OutboundAdapter)
+3. **MqttPublisher** — 서버→기기 명령 발행 서비스
+4. **MqttSubscriber** — 기기→서버 데이터 수신 리스너
+5. **ACK 처리** — 명령 전달 확인 메커니즘 (QoS 1+ 응답 토픽)
+
+### 토픽 체계
+```
+pet/{houseId}/sensor/data      — 센서 데이터 수신 (subscribe)
+pet/{houseId}/sensor/alert     — 알림 발행 (publish)
+pet/{houseId}/cam/stream       — 카메라 스트림 제어
+pet/{houseId}/cam/ptz          — PTZ 제어 명령
+pet/{houseId}/device/status    — 기기 상태 (online/offline)
+pet/{houseId}/device/command   — 기기 제어 명령 (팬, 급식 등)
+pet/{houseId}/device/ack       — 명령 ACK 응답
+```
+
+### 필요한 의존성
+```gradle
+implementation 'org.springframework.boot:spring-boot-starter-integration'
+implementation 'org.springframework.integration:spring-integration-mqtt'
+```
+
+---
+
+## [TASK-2] Auth — JWT + OAuth2 소셜 로그인 (5개)
+우선순위: ★★★★★ (MQTT와 동시 또는 직후)
+
+### 구현 목표
+JWT 기반 인증 + 카카오/Google/Apple 소셜 로그인. 모든 API가 의존하는 인증 기반.
+
+### 구현 항목
+1. **SecurityConfig** — 필터 체인, CORS, 경로별 인증/인가
+2. **JWT 발급** — Access Token (30분) + Refresh Token (14일) 발급
+3. **JWT 갱신** — Refresh Token으로 Access Token 재발급
+4. **OAuth2 로그인** — 카카오, Google, Apple 소셜 로그인 핸들러
+5. **User 엔티티 확장** — provider, providerId, role 등 필드 추가
+
+### 필요한 의존성
+```gradle
+implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
+runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
+runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
+```
+
+### User 엔티티 확장 필드
+- provider (KAKAO, GOOGLE, APPLE, LOCAL)
+- providerId (소셜 고유 ID)
+- role (USER, ADMIN)
+- refreshToken
+
+---
+
+## [TASK-3a] Device CRUD (5개)
+우선순위: ★★★★☆
+
+### 구현 목표
+펫하우스 기기의 기본 CRUD API.
+
+### 구현 항목
+1. **기기 등록 (POST /devices)** — 신규 PetHouse 생성
+2. **기기 목록 조회 (GET /devices)** — 사용자의 기기 리스트
+3. **기기 상세 조회 (GET /devices/{houseId})** — 단일 기기 정보
+4. **기기 수정 (PUT /devices/{houseId})** — 닉네임 등 정보 수정
+5. **기기 삭제 (DELETE /devices/{houseId})** — 기기 제거 + 연관 데이터 정리
+
+### PetHouse 엔티티 확장 필드
+- serialNumber (시리얼 번호)
+- macAddress (MAC 주소)
+- firmwareVersion
+- deviceType (HOUSE, COLLAR)
+- provisioningStatus (PENDING, CLAIMED, ACTIVE)
+
+---
+
+## [TASK-3b] Provisioning (6개)
+우선순위: ★★★☆☆ (TASK-3a 완료 후)
+
+### 구현 목표
+QR→BLE→Wi-Fi→Claim 프로비저닝 플로우 + MQTT 연결 상태 관리.
+
+### 구현 항목
+1. **QR 코드 생성 (POST /devices/qr/generate)** — 기기 시리얼 번호 → QR 코드 생성
+2. **QR 코드 검증 (POST /devices/qr/verify)** — 앱에서 QR 스캔 → 시리얼 번호 반환
+3. **프로비저닝 시작 (POST /devices/{houseId}/provision)** — BLE 연결 후 Wi-Fi 정보 전달 API
+4. **기기 Claim (POST /devices/claim)** — 기기가 서버에 최초 연결 시 소유권 등록
+5. **연결 상태 관리** — MQTT Last Will을 활용한 online/offline 추적
+6. **시리얼 번호 검증 (GET /devices/serial/check)** — 시리얼 존재/사용 여부 확인
+
+---
+
+## [TASK-4] Sensor — CO2/온도/습도 (5개)
+우선순위: ★★★☆☆
+
+### 구현 목표
+MQTT로 센서 데이터를 수신하여 InfluxDB에 저장하고, WebSocket으로 클라이언트에 실시간 푸시.
+
+### 구현 항목
+1. **MQTT Sensor Subscriber** — `pet/{houseId}/sensor/data` 토픽 구독, JSON 파싱
+2. **InfluxDB 저장** — 시계열 데이터 저장 (온도, 습도, CO2)
+3. **WebSocket 실시간 푸시** — STOMP를 통해 클라이언트에 실시간 데이터 전달
+4. **알림 임계값 설정/조회** — 사용자별 온도/습도/CO2 임계값 CRUD
+5. **센서 이력 조회 API** — 기간별 데이터 조회 (차트용, InfluxDB 쿼리)
+
+### 필요한 의존성
+```gradle
+implementation 'org.springframework.boot:spring-boot-starter-websocket'
+implementation 'com.influxdb:influxdb-client-java:7.2.0'
+```
+
+### InfluxDB Docker 설정
+```yaml
+# docker-compose.yml에 추가
+influxdb:
+  image: influxdb:2.7
+  ports:
+    - "8086:8086"
+  environment:
+    DOCKER_INFLUXDB_INIT_MODE: setup
+    DOCKER_INFLUXDB_INIT_USERNAME: admin
+    DOCKER_INFLUXDB_INIT_PASSWORD: ${INFLUXDB_PASSWORD}
+    DOCKER_INFLUXDB_INIT_ORG: pethouse
+    DOCKER_INFLUXDB_INIT_BUCKET: sensor_data
+```
+
+### 센서 데이터 JSON 포맷 (MQTT 수신)
+```json
+{
+  "houseId": 1,
+  "temperature": 25.3,
+  "humidity": 60.2,
+  "co2": 412.5,
+  "timestamp": "2025-10-13T15:30:00"
+}
+```
+
+---
+
+## [TASK-5a] Camera 스트리밍 — WebRTC + HLS (7개)
+우선순위: ★★☆☆☆ (마지막)
+
+### 구현 목표
+WebRTC signaling 서버 + HLS 스트리밍 기능.
+
+### 구현 항목
+**WebRTC Signaling (4개)**
+1. POST `/cameras/{houseId}/offer` — WebRTC offer 전달
+2. POST `/cameras/{houseId}/answer` — WebRTC answer 전달
+3. POST `/cameras/{houseId}/ice-candidate` — ICE candidate 교환
+4. DELETE `/cameras/{houseId}/session` — 스트리밍 세션 종료
+
+**HLS 스트리밍 (3개)**
+5. POST `/cameras/{houseId}/hls/start` — HLS 스트리밍 시작
+6. DELETE `/cameras/{houseId}/hls/stop` — HLS 스트리밍 중지
+7. GET `/cameras/{houseId}/hls/playlist` — .m3u8 플레이리스트 반환
+
+---
+
+## [TASK-5b] Camera 제어 — PTZ + 녹화 + 스냅샷 (11개)
+우선순위: ★★☆☆☆ (TASK-5a 완료 후)
+
+### 구현 목표
+카메라 PTZ 제어 (MQTT 명령), 녹화 파일 관리, 스냅샷 캡처.
+
+### 구현 항목
+**PTZ 제어 (3개)**
+1. POST `/cameras/{houseId}/ptz/move` — 카메라 이동 (pan/tilt)
+2. POST `/cameras/{houseId}/ptz/zoom` — 줌 제어
+3. POST `/cameras/{houseId}/ptz/preset` — 프리셋 위치 이동
+
+**녹화 (5개)**
+4. POST `/cameras/{houseId}/recording/start` — 녹화 시작
+5. POST `/cameras/{houseId}/recording/stop` — 녹화 중지
+6. GET `/cameras/{houseId}/recordings` — 녹화 파일 목록
+7. GET `/cameras/{houseId}/recordings/{id}` — 녹화 파일 다운로드
+8. DELETE `/cameras/{houseId}/recordings/{id}` — 녹화 파일 삭제
+
+**스냅샷 (3개)**
+9. POST `/cameras/{houseId}/snapshot` — 스냅샷 캡처
+10. GET `/cameras/{houseId}/snapshots` — 스냅샷 목록
+11. GET `/cameras/{houseId}/snapshots/{id}` — 스냅샷 다운로드
+
+---
+
+# 작업 스타일
+
+- TASK를 받으면 해당 도메인의 모든 항목을 끝까지 구현한다. 중간에 멈추지 않는다.
+- Entity, Repository, Service, Controller, DTO, Config, 테스트까지 전부 작성한다.
+- 코드를 생략하거나 "나머지는 비슷하게..." 같은 축약을 하지 않는다.
+- 빌드가 되는 상태로 완성한다.
+- 구현이 끝나면 변경된 파일 목록과 다음 TASK 안내를 출력한다.
+
+---
+
+# 작업 요청 방법
+
+새 대화에서 아래처럼 요청:
+```
+TASK-1 (MQTT 인프라) 구현해줘
+```
+
+## TASK 목록 및 의존 순서
+
+```
+TASK-1 (MQTT) → TASK-2 (Auth) → TASK-3a (Device CRUD) → TASK-3b (Provisioning) → TASK-4 (Sensor) → TASK-5a (Camera 스트리밍) → TASK-5b (Camera 녹화/PTZ)
+```
+
+| TASK | 내용 | 개수 |
+|------|------|------|
+| TASK-1 | MQTT 인프라 (EMQX, Publisher/Subscriber, ACK) | 5개 |
+| TASK-2 | Auth (SecurityConfig, JWT, OAuth2 카카오/Google/Apple) | 5개 |
+| TASK-3a | Device CRUD (등록/조회/수정/삭제/유형코드) | 5개 |
+| TASK-3b | Provisioning (QR/BLE/Wi-Fi Claim/연결상태/시리얼검증) | 6개 |
+| TASK-4 | Sensor (MQTT Subscribe→InfluxDB→WebSocket 푸시, 알림 임계값, 이력 조회) | 5개 |
+| TASK-5a | Camera 스트리밍 (WebRTC signaling 4개 + HLS 3개) | 7개 |
+| TASK-5b | Camera 제어 (PTZ 3개 + 녹화 5개 + 스냅샷 3개) | 11개 |

--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,11 @@ dependencies {
 
     implementation 'org.springframework.boot:spring-boot-starter-security'
 
+    // MQTT (Spring Integration)
+    implementation 'org.springframework.boot:spring-boot-starter-integration'
+    implementation 'org.springframework.integration:spring-integration-mqtt'
+    implementation 'org.eclipse.paho:org.eclipse.paho.client.mqttv3:1.2.5'
+
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,24 @@ services:
     volumes:
       - mysql_data:/var/lib/mysql
 
+  emqx:
+    image: emqx/emqx:5.8
+    container_name: pet-house-emqx
+    restart: always
+    ports:
+      - "1883:1883"       # MQTT TCP
+      - "8083:8083"       # MQTT WebSocket
+      - "8883:8883"       # MQTT SSL
+      - "18083:18083"     # EMQX Dashboard
+    volumes:
+      - emqx_data:/opt/emqx/data
+      - emqx_log:/opt/emqx/log
+    environment:
+      EMQX_NAME: pet-house-emqx
+      EMQX_HOST: 127.0.0.1
+      EMQX_LISTENERS__TCP__DEFAULT__ACCEPTORS: 8
+      EMQX_LISTENERS__TCP__DEFAULT__MAX_CONNECTIONS: 1024000
+
   app:
     build: .
     container_name: pet-house-app
@@ -20,11 +38,17 @@ services:
       - "8080:8080"
     depends_on:
       - db
+      - emqx
     environment:
       SPRING_DATASOURCE_URL: jdbc:mysql://db:3306/pet_house_db?serverTimezone=Asia/Seoul&createDatabaseIfNotExist=true
       DB_USERNAME: ${DB_USERNAME}
       DB_PASSWORD: ${DB_PASSWORD}
       SPRING_JPA_HIBERNATE_DDL_AUTO: update
+      MQTT_BROKER_URL: tcp://emqx:1883
+      MQTT_USERNAME: ${MQTT_USERNAME:}
+      MQTT_PASSWORD: ${MQTT_PASSWORD:}
 
 volumes:
   mysql_data:
+  emqx_data:
+  emqx_log:

--- a/src/main/java/com/capstone/pethouse/global/config/SecurityConfig.java
+++ b/src/main/java/com/capstone/pethouse/global/config/SecurityConfig.java
@@ -1,0 +1,26 @@
+package com.capstone.pethouse.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(AbstractHttpConfigurer::disable)
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(auth -> auth
+                        .anyRequest().permitAll() // TASK-2에서 JWT 인증 적용 예정
+                );
+
+        return http.build();
+    }
+}

--- a/src/main/java/com/capstone/pethouse/infra/mqtt/MqttCommandService.java
+++ b/src/main/java/com/capstone/pethouse/infra/mqtt/MqttCommandService.java
@@ -1,0 +1,52 @@
+package com.capstone.pethouse.infra.mqtt;
+
+import com.capstone.pethouse.infra.mqtt.ack.AckResult;
+import com.capstone.pethouse.infra.mqtt.ack.MqttAckManager;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class MqttCommandService {
+
+    private final MqttPublisher publisher;
+    private final MqttAckManager ackManager;
+
+    public CompletableFuture<AckResult> sendCommand(Long houseId, String action, Map<String, Object> params) {
+        String commandId = ackManager.generateCommandId();
+
+        Map<String, Object> command = Map.of(
+                "commandId", commandId,
+                "action", action,
+                "params", params
+        );
+
+        CompletableFuture<AckResult> future = ackManager.register(commandId);
+        publisher.sendDeviceCommand(houseId, command);
+
+        log.info("Command sent — houseId={}, action={}, commandId={}", houseId, action, commandId);
+        return future;
+    }
+
+    public CompletableFuture<AckResult> sendCommand(Long houseId, String action, Map<String, Object> params, long timeoutSeconds) {
+        String commandId = ackManager.generateCommandId();
+
+        Map<String, Object> command = Map.of(
+                "commandId", commandId,
+                "action", action,
+                "params", params
+        );
+
+        CompletableFuture<AckResult> future = ackManager.register(commandId, timeoutSeconds);
+        publisher.sendDeviceCommand(houseId, command);
+
+        log.info("Command sent — houseId={}, action={}, commandId={}, timeout={}s",
+                houseId, action, commandId, timeoutSeconds);
+        return future;
+    }
+}

--- a/src/main/java/com/capstone/pethouse/infra/mqtt/MqttPublisher.java
+++ b/src/main/java/com/capstone/pethouse/infra/mqtt/MqttPublisher.java
@@ -1,0 +1,76 @@
+package com.capstone.pethouse.infra.mqtt;
+
+import com.capstone.pethouse.infra.mqtt.config.MqttProperties;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.integration.mqtt.support.MqttHeaders;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class MqttPublisher {
+
+    private final MessageChannel mqttOutboundChannel;
+    private final MqttProperties mqttProperties;
+    private final ObjectMapper objectMapper;
+
+    public void publish(String topic, String payload) {
+        publish(topic, payload, mqttProperties.getDefaultQos());
+    }
+
+    public void publish(String topic, String payload, int qos) {
+        Message<String> message = MessageBuilder
+                .withPayload(payload)
+                .setHeader(MqttHeaders.TOPIC, topic)
+                .setHeader(MqttHeaders.QOS, qos)
+                .setHeader(MqttHeaders.RETAINED, false)
+                .build();
+
+        mqttOutboundChannel.send(message);
+        log.debug("MQTT Published → topic={}, payload={}", topic, payload);
+    }
+
+    public void publishJson(String topic, Object payload) {
+        try {
+            String json = objectMapper.writeValueAsString(payload);
+            publish(topic, json);
+        } catch (JsonProcessingException e) {
+            log.error("Failed to serialize MQTT payload to JSON: {}", e.getMessage(), e);
+            throw new RuntimeException("MQTT payload serialization failed", e);
+        }
+    }
+
+    public void publishJson(String topic, Object payload, int qos) {
+        try {
+            String json = objectMapper.writeValueAsString(payload);
+            publish(topic, json, qos);
+        } catch (JsonProcessingException e) {
+            log.error("Failed to serialize MQTT payload to JSON: {}", e.getMessage(), e);
+            throw new RuntimeException("MQTT payload serialization failed", e);
+        }
+    }
+
+    // === 편의 메서드 ===
+
+    public void sendDeviceCommand(Long houseId, Object command) {
+        publishJson(MqttTopicManager.deviceCommand(houseId), command);
+    }
+
+    public void sendSensorAlert(Long houseId, Object alert) {
+        publishJson(MqttTopicManager.sensorAlert(houseId), alert);
+    }
+
+    public void sendCamPtz(Long houseId, Object ptzCommand) {
+        publishJson(MqttTopicManager.camPtz(houseId), ptzCommand);
+    }
+
+    public void sendCamStream(Long houseId, Object streamCommand) {
+        publishJson(MqttTopicManager.camStream(houseId), streamCommand);
+    }
+}

--- a/src/main/java/com/capstone/pethouse/infra/mqtt/MqttSubscriber.java
+++ b/src/main/java/com/capstone/pethouse/infra/mqtt/MqttSubscriber.java
@@ -1,0 +1,60 @@
+package com.capstone.pethouse.infra.mqtt;
+
+import com.capstone.pethouse.infra.mqtt.handler.MqttMessageHandler;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.integration.annotation.ServiceActivator;
+import org.springframework.integration.mqtt.support.MqttHeaders;
+import org.springframework.messaging.Message;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Slf4j
+@Component
+public class MqttSubscriber {
+
+    private final List<MqttMessageHandler> handlers;
+
+    public MqttSubscriber(List<MqttMessageHandler> handlers) {
+        this.handlers = handlers;
+        log.info("MQTT Subscriber initialized with {} handler(s): {}",
+                handlers.size(),
+                handlers.stream().map(h -> h.getClass().getSimpleName()).toList());
+    }
+
+    @ServiceActivator(inputChannel = "mqttInboundChannel")
+    public void handleMessage(Message<?> message) {
+        String topic = (String) message.getHeaders().get(MqttHeaders.RECEIVED_TOPIC);
+        String payload = message.getPayload().toString();
+
+        if (topic == null) {
+            log.warn("Received MQTT message with null topic, ignoring");
+            return;
+        }
+
+        log.debug("MQTT Received ← topic={}, payload={}", topic, payload);
+
+        try {
+            Long houseId = MqttTopicManager.extractHouseId(topic);
+            String category = MqttTopicManager.extractCategory(topic);
+
+            boolean handled = false;
+            for (MqttMessageHandler handler : handlers) {
+                if (handler.supports(category)) {
+                    handler.handle(houseId, category, payload);
+                    handled = true;
+                }
+            }
+
+            if (!handled) {
+                log.warn("No handler found for MQTT category: {} (topic: {})", category, topic);
+            }
+        } catch (NumberFormatException e) {
+            log.error("Failed to parse houseId from topic: {}", topic, e);
+        } catch (IllegalArgumentException e) {
+            log.error("Invalid MQTT topic format: {}", topic, e);
+        } catch (Exception e) {
+            log.error("Error handling MQTT message on topic {}: {}", topic, e.getMessage(), e);
+        }
+    }
+}

--- a/src/main/java/com/capstone/pethouse/infra/mqtt/MqttTopicManager.java
+++ b/src/main/java/com/capstone/pethouse/infra/mqtt/MqttTopicManager.java
@@ -1,0 +1,79 @@
+package com.capstone.pethouse.infra.mqtt;
+
+public final class MqttTopicManager {
+
+    private MqttTopicManager() {}
+
+    private static final String ROOT = "pet";
+
+    // === Sensor ===
+    public static String sensorData(Long houseId) {
+        return ROOT + "/" + houseId + "/sensor/data";
+    }
+
+    public static String sensorAlert(Long houseId) {
+        return ROOT + "/" + houseId + "/sensor/alert";
+    }
+
+    // === Device ===
+    public static String deviceStatus(Long houseId) {
+        return ROOT + "/" + houseId + "/device/status";
+    }
+
+    public static String deviceCommand(Long houseId) {
+        return ROOT + "/" + houseId + "/device/command";
+    }
+
+    public static String deviceAck(Long houseId) {
+        return ROOT + "/" + houseId + "/device/ack";
+    }
+
+    // === Camera ===
+    public static String camStream(Long houseId) {
+        return ROOT + "/" + houseId + "/cam/stream";
+    }
+
+    public static String camPtz(Long houseId) {
+        return ROOT + "/" + houseId + "/cam/ptz";
+    }
+
+    // === Wildcard Patterns (Subscribe용) ===
+    public static String allSensorData() {
+        return ROOT + "/+/sensor/data";
+    }
+
+    public static String allDeviceStatus() {
+        return ROOT + "/+/device/status";
+    }
+
+    public static String allDeviceAck() {
+        return ROOT + "/+/device/ack";
+    }
+
+    public static String allCam() {
+        return ROOT + "/+/cam/#";
+    }
+
+    // === 토픽에서 houseId 추출 ===
+    public static Long extractHouseId(String topic) {
+        String[] parts = topic.split("/");
+        if (parts.length < 2) {
+            throw new IllegalArgumentException("Invalid topic format: " + topic);
+        }
+        return Long.parseLong(parts[1]);
+    }
+
+    // === 토픽에서 서브 카테고리 추출 (예: "sensor/data", "device/ack") ===
+    public static String extractCategory(String topic) {
+        String[] parts = topic.split("/");
+        if (parts.length < 4) {
+            throw new IllegalArgumentException("Invalid topic format: " + topic);
+        }
+        StringBuilder sb = new StringBuilder();
+        for (int i = 2; i < parts.length; i++) {
+            if (i > 2) sb.append("/");
+            sb.append(parts[i]);
+        }
+        return sb.toString();
+    }
+}

--- a/src/main/java/com/capstone/pethouse/infra/mqtt/ack/AckResult.java
+++ b/src/main/java/com/capstone/pethouse/infra/mqtt/ack/AckResult.java
@@ -1,0 +1,24 @@
+package com.capstone.pethouse.infra.mqtt.ack;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class AckResult {
+
+    private final boolean success;
+    private final String message;
+
+    public static AckResult success(String message) {
+        return new AckResult(true, message);
+    }
+
+    public static AckResult failure(String message) {
+        return new AckResult(false, message);
+    }
+
+    public static AckResult timeout() {
+        return new AckResult(false, "ACK timeout");
+    }
+}

--- a/src/main/java/com/capstone/pethouse/infra/mqtt/ack/MqttAckManager.java
+++ b/src/main/java/com/capstone/pethouse/infra/mqtt/ack/MqttAckManager.java
@@ -1,0 +1,68 @@
+package com.capstone.pethouse.infra.mqtt.ack;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.UUID;
+import java.util.concurrent.*;
+
+@Slf4j
+@Component
+public class MqttAckManager {
+
+    private static final long DEFAULT_TIMEOUT_SECONDS = 10;
+
+    private final ConcurrentMap<String, CompletableFuture<AckResult>> pendingAcks = new ConcurrentHashMap<>();
+
+    public String generateCommandId() {
+        return UUID.randomUUID().toString().substring(0, 8);
+    }
+
+    public CompletableFuture<AckResult> register(String commandId) {
+        CompletableFuture<AckResult> future = new CompletableFuture<>();
+        pendingAcks.put(commandId, future);
+
+        // 타임아웃 후 자동 제거
+        CompletableFuture.delayedExecutor(DEFAULT_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+                .execute(() -> {
+                    CompletableFuture<AckResult> pending = pendingAcks.remove(commandId);
+                    if (pending != null && !pending.isDone()) {
+                        pending.complete(AckResult.timeout());
+                        log.warn("ACK timeout for commandId={}", commandId);
+                    }
+                });
+
+        return future;
+    }
+
+    public CompletableFuture<AckResult> register(String commandId, long timeoutSeconds) {
+        CompletableFuture<AckResult> future = new CompletableFuture<>();
+        pendingAcks.put(commandId, future);
+
+        CompletableFuture.delayedExecutor(timeoutSeconds, TimeUnit.SECONDS)
+                .execute(() -> {
+                    CompletableFuture<AckResult> pending = pendingAcks.remove(commandId);
+                    if (pending != null && !pending.isDone()) {
+                        pending.complete(AckResult.timeout());
+                        log.warn("ACK timeout for commandId={}", commandId);
+                    }
+                });
+
+        return future;
+    }
+
+    public void complete(String commandId, boolean success, String message) {
+        CompletableFuture<AckResult> future = pendingAcks.remove(commandId);
+        if (future != null) {
+            AckResult result = success ? AckResult.success(message) : AckResult.failure(message);
+            future.complete(result);
+            log.debug("ACK completed — commandId={}, success={}", commandId, success);
+        } else {
+            log.warn("ACK received for unknown/expired commandId={}", commandId);
+        }
+    }
+
+    public int pendingCount() {
+        return pendingAcks.size();
+    }
+}

--- a/src/main/java/com/capstone/pethouse/infra/mqtt/config/MqttConfig.java
+++ b/src/main/java/com/capstone/pethouse/infra/mqtt/config/MqttConfig.java
@@ -1,0 +1,98 @@
+package com.capstone.pethouse.infra.mqtt.config;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.eclipse.paho.client.mqttv3.MqttConnectOptions;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.integration.channel.DirectChannel;
+import org.springframework.integration.channel.PublishSubscribeChannel;
+import org.springframework.integration.core.MessageProducer;
+import org.springframework.integration.mqtt.core.DefaultMqttPahoClientFactory;
+import org.springframework.integration.mqtt.core.MqttPahoClientFactory;
+import org.springframework.integration.mqtt.inbound.MqttPahoMessageDrivenChannelAdapter;
+import org.springframework.integration.mqtt.outbound.MqttPahoMessageHandler;
+import org.springframework.integration.mqtt.support.DefaultPahoMessageConverter;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.integration.annotation.ServiceActivator;
+import org.springframework.messaging.MessageHandler;
+import org.springframework.util.StringUtils;
+
+@Slf4j
+@RequiredArgsConstructor
+@EnableConfigurationProperties(MqttProperties.class)
+@Configuration
+public class MqttConfig {
+
+    private final MqttProperties mqttProperties;
+
+    @Bean
+    public MqttPahoClientFactory mqttClientFactory() {
+        DefaultMqttPahoClientFactory factory = new DefaultMqttPahoClientFactory();
+        MqttConnectOptions options = new MqttConnectOptions();
+
+        options.setServerURIs(new String[]{mqttProperties.getBroker().getUrl()});
+        options.setKeepAliveInterval(mqttProperties.getKeepAliveInterval());
+        options.setConnectionTimeout(mqttProperties.getConnectionTimeout());
+        options.setAutomaticReconnect(mqttProperties.isAutoReconnect());
+        options.setCleanSession(mqttProperties.isCleanSession());
+
+        if (StringUtils.hasText(mqttProperties.getUsername())) {
+            options.setUserName(mqttProperties.getUsername());
+        }
+        if (StringUtils.hasText(mqttProperties.getPassword())) {
+            options.setPassword(mqttProperties.getPassword().toCharArray());
+        }
+
+        factory.setConnectionOptions(options);
+        return factory;
+    }
+
+    // === Outbound (Server → Device) ===
+
+    @Bean
+    public MessageChannel mqttOutboundChannel() {
+        return new DirectChannel();
+    }
+
+    @Bean
+    @ServiceActivator(inputChannel = "mqttOutboundChannel")
+    public MessageHandler mqttOutboundHandler(MqttPahoClientFactory factory) {
+        String clientId = mqttProperties.getClient().getId() + "-pub";
+        MqttPahoMessageHandler handler = new MqttPahoMessageHandler(clientId, factory);
+        handler.setAsync(true);
+        handler.setDefaultQos(mqttProperties.getDefaultQos());
+        handler.setDefaultRetained(false);
+        return handler;
+    }
+
+    // === Inbound (Device → Server) ===
+
+    @Bean
+    public MessageChannel mqttInboundChannel() {
+        return new PublishSubscribeChannel();
+    }
+
+    @Bean
+    public MessageProducer mqttInboundAdapter(MqttPahoClientFactory factory) {
+        String clientId = mqttProperties.getClient().getId() + "-sub";
+        MqttPahoMessageDrivenChannelAdapter adapter =
+                new MqttPahoMessageDrivenChannelAdapter(clientId, factory);
+
+        DefaultPahoMessageConverter converter = new DefaultPahoMessageConverter();
+        converter.setPayloadAsBytes(false);
+        adapter.setConverter(converter);
+        adapter.setQos(mqttProperties.getDefaultQos());
+        adapter.setOutputChannel(mqttInboundChannel());
+
+        // 기본 구독 토픽 (와일드카드로 모든 하우스의 모든 메시지 수신)
+        adapter.addTopic("pet/+/sensor/data", mqttProperties.getDefaultQos());
+        adapter.addTopic("pet/+/device/status", mqttProperties.getDefaultQos());
+        adapter.addTopic("pet/+/device/ack", mqttProperties.getDefaultQos());
+        adapter.addTopic("pet/+/cam/#", mqttProperties.getDefaultQos());
+
+        log.info("MQTT Inbound Adapter initialized - subscribing to pet/+/sensor/data, pet/+/device/status, pet/+/device/ack, pet/+/cam/#");
+        return adapter;
+    }
+}

--- a/src/main/java/com/capstone/pethouse/infra/mqtt/config/MqttProperties.java
+++ b/src/main/java/com/capstone/pethouse/infra/mqtt/config/MqttProperties.java
@@ -1,0 +1,33 @@
+package com.capstone.pethouse.infra.mqtt.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Getter
+@Setter
+@ConfigurationProperties(prefix = "mqtt")
+public class MqttProperties {
+
+    private Broker broker = new Broker();
+    private Client client = new Client();
+    private String username;
+    private String password;
+    private int defaultQos = 1;
+    private int keepAliveInterval = 60;
+    private int connectionTimeout = 30;
+    private boolean autoReconnect = true;
+    private boolean cleanSession = true;
+
+    @Getter
+    @Setter
+    public static class Broker {
+        private String url = "tcp://localhost:1883";
+    }
+
+    @Getter
+    @Setter
+    public static class Client {
+        private String id = "pet-house-server";
+    }
+}

--- a/src/main/java/com/capstone/pethouse/infra/mqtt/controller/MqttTestController.java
+++ b/src/main/java/com/capstone/pethouse/infra/mqtt/controller/MqttTestController.java
@@ -1,0 +1,70 @@
+package com.capstone.pethouse.infra.mqtt.controller;
+
+import com.capstone.pethouse.infra.mqtt.MqttCommandService;
+import com.capstone.pethouse.infra.mqtt.MqttPublisher;
+import com.capstone.pethouse.infra.mqtt.MqttTopicManager;
+import com.capstone.pethouse.infra.mqtt.ack.AckResult;
+import com.capstone.pethouse.infra.mqtt.ack.MqttAckManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+@RequiredArgsConstructor
+@RequestMapping("/mqtt/test")
+@RestController
+public class MqttTestController {
+
+    private final MqttPublisher publisher;
+    private final MqttCommandService commandService;
+    private final MqttAckManager ackManager;
+
+    @PostMapping("/publish")
+    public ResponseEntity<Map<String, String>> publish(
+            @RequestParam String topic,
+            @RequestBody String payload
+    ) {
+        publisher.publish(topic, payload);
+        return ResponseEntity.ok(Map.of(
+                "status", "sent",
+                "topic", topic
+        ));
+    }
+
+    @PostMapping("/command/{houseId}")
+    public CompletableFuture<ResponseEntity<Map<String, Object>>> sendCommand(
+            @PathVariable Long houseId,
+            @RequestParam String action,
+            @RequestBody(required = false) Map<String, Object> params
+    ) {
+        if (params == null) params = Map.of();
+
+        return commandService.sendCommand(houseId, action, params)
+                .thenApply(ackResult -> ResponseEntity.ok(Map.of(
+                        "houseId", houseId,
+                        "action", action,
+                        "ackSuccess", ackResult.isSuccess(),
+                        "ackMessage", ackResult.getMessage()
+                )));
+    }
+
+    @GetMapping("/ack/pending")
+    public ResponseEntity<Map<String, Integer>> pendingAcks() {
+        return ResponseEntity.ok(Map.of("pendingAckCount", ackManager.pendingCount()));
+    }
+
+    @GetMapping("/topics/{houseId}")
+    public ResponseEntity<Map<String, String>> getTopics(@PathVariable Long houseId) {
+        return ResponseEntity.ok(Map.of(
+                "sensorData", MqttTopicManager.sensorData(houseId),
+                "sensorAlert", MqttTopicManager.sensorAlert(houseId),
+                "deviceStatus", MqttTopicManager.deviceStatus(houseId),
+                "deviceCommand", MqttTopicManager.deviceCommand(houseId),
+                "deviceAck", MqttTopicManager.deviceAck(houseId),
+                "camStream", MqttTopicManager.camStream(houseId),
+                "camPtz", MqttTopicManager.camPtz(houseId)
+        ));
+    }
+}

--- a/src/main/java/com/capstone/pethouse/infra/mqtt/handler/DeviceAckHandler.java
+++ b/src/main/java/com/capstone/pethouse/infra/mqtt/handler/DeviceAckHandler.java
@@ -1,0 +1,44 @@
+package com.capstone.pethouse.infra.mqtt.handler;
+
+import com.capstone.pethouse.infra.mqtt.ack.MqttAckManager;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class DeviceAckHandler implements MqttMessageHandler {
+
+    private final MqttAckManager ackManager;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public boolean supports(String category) {
+        return "device/ack".equals(category);
+    }
+
+    @Override
+    public void handle(Long houseId, String category, String payload) {
+        try {
+            JsonNode node = objectMapper.readTree(payload);
+            String commandId = node.path("commandId").asText(null);
+            boolean success = node.path("success").asBoolean(false);
+            String message = node.path("message").asText("");
+
+            if (commandId == null) {
+                log.warn("ACK received without commandId — houseId={}, payload={}", houseId, payload);
+                return;
+            }
+
+            log.info("ACK received — houseId={}, commandId={}, success={}, message={}",
+                    houseId, commandId, success, message);
+
+            ackManager.complete(commandId, success, message);
+        } catch (Exception e) {
+            log.error("Failed to parse ACK payload — houseId={}, payload={}", houseId, payload, e);
+        }
+    }
+}

--- a/src/main/java/com/capstone/pethouse/infra/mqtt/handler/DeviceStatusHandler.java
+++ b/src/main/java/com/capstone/pethouse/infra/mqtt/handler/DeviceStatusHandler.java
@@ -1,0 +1,20 @@
+package com.capstone.pethouse.infra.mqtt.handler;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class DeviceStatusHandler implements MqttMessageHandler {
+
+    @Override
+    public boolean supports(String category) {
+        return "device/status".equals(category);
+    }
+
+    @Override
+    public void handle(Long houseId, String category, String payload) {
+        log.info("Device status update — houseId={}, status={}", houseId, payload);
+        // TASK-3b에서 PetHouse 상태(ONLINE/OFFLINE) 업데이트 구현 예정
+    }
+}

--- a/src/main/java/com/capstone/pethouse/infra/mqtt/handler/MqttMessageHandler.java
+++ b/src/main/java/com/capstone/pethouse/infra/mqtt/handler/MqttMessageHandler.java
@@ -1,0 +1,8 @@
+package com.capstone.pethouse.infra.mqtt.handler;
+
+public interface MqttMessageHandler {
+
+    boolean supports(String category);
+
+    void handle(Long houseId, String category, String payload);
+}

--- a/src/main/java/com/capstone/pethouse/infra/mqtt/handler/SensorDataHandler.java
+++ b/src/main/java/com/capstone/pethouse/infra/mqtt/handler/SensorDataHandler.java
@@ -1,0 +1,20 @@
+package com.capstone.pethouse.infra.mqtt.handler;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class SensorDataHandler implements MqttMessageHandler {
+
+    @Override
+    public boolean supports(String category) {
+        return "sensor/data".equals(category);
+    }
+
+    @Override
+    public void handle(Long houseId, String category, String payload) {
+        log.info("Sensor data received — houseId={}, payload={}", houseId, payload);
+        // TASK-4에서 InfluxDB 저장 + WebSocket 푸시 구현 예정
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -13,3 +13,14 @@ server.servlet.context-path=/api
 
 spring.jpa.properties.hibernate.default_batch_size=100
 spring.datasource.hikari.initialization-fail-timeout=60000
+
+# MQTT (EMQX)
+mqtt.broker.url=${MQTT_BROKER_URL:tcp://localhost:1883}
+mqtt.client.id=pet-house-server-${random.uuid}
+mqtt.username=${MQTT_USERNAME:}
+mqtt.password=${MQTT_PASSWORD:}
+mqtt.default-qos=1
+mqtt.keep-alive-interval=60
+mqtt.connection-timeout=30
+mqtt.auto-reconnect=true
+mqtt.clean-session=true

--- a/src/test/java/com/capstone/pethouse/infra/mqtt/MqttTopicManagerTest.java
+++ b/src/test/java/com/capstone/pethouse/infra/mqtt/MqttTopicManagerTest.java
@@ -1,0 +1,66 @@
+package com.capstone.pethouse.infra.mqtt;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class MqttTopicManagerTest {
+
+    @Test
+    @DisplayName("houseId 기반 센서 데이터 토픽 생성")
+    void sensorDataTopic() {
+        assertThat(MqttTopicManager.sensorData(1L)).isEqualTo("pet/1/sensor/data");
+        assertThat(MqttTopicManager.sensorData(123L)).isEqualTo("pet/123/sensor/data");
+    }
+
+    @Test
+    @DisplayName("houseId 기반 디바이스 관련 토픽 생성")
+    void deviceTopics() {
+        assertThat(MqttTopicManager.deviceStatus(5L)).isEqualTo("pet/5/device/status");
+        assertThat(MqttTopicManager.deviceCommand(5L)).isEqualTo("pet/5/device/command");
+        assertThat(MqttTopicManager.deviceAck(5L)).isEqualTo("pet/5/device/ack");
+    }
+
+    @Test
+    @DisplayName("houseId 기반 카메라 토픽 생성")
+    void cameraTopics() {
+        assertThat(MqttTopicManager.camStream(10L)).isEqualTo("pet/10/cam/stream");
+        assertThat(MqttTopicManager.camPtz(10L)).isEqualTo("pet/10/cam/ptz");
+    }
+
+    @Test
+    @DisplayName("와일드카드 토픽 생성")
+    void wildcardTopics() {
+        assertThat(MqttTopicManager.allSensorData()).isEqualTo("pet/+/sensor/data");
+        assertThat(MqttTopicManager.allDeviceStatus()).isEqualTo("pet/+/device/status");
+        assertThat(MqttTopicManager.allDeviceAck()).isEqualTo("pet/+/device/ack");
+        assertThat(MqttTopicManager.allCam()).isEqualTo("pet/+/cam/#");
+    }
+
+    @Test
+    @DisplayName("토픽에서 houseId 추출")
+    void extractHouseId() {
+        assertThat(MqttTopicManager.extractHouseId("pet/42/sensor/data")).isEqualTo(42L);
+        assertThat(MqttTopicManager.extractHouseId("pet/1/device/ack")).isEqualTo(1L);
+    }
+
+    @Test
+    @DisplayName("토픽에서 카테고리 추출")
+    void extractCategory() {
+        assertThat(MqttTopicManager.extractCategory("pet/1/sensor/data")).isEqualTo("sensor/data");
+        assertThat(MqttTopicManager.extractCategory("pet/1/device/ack")).isEqualTo("device/ack");
+        assertThat(MqttTopicManager.extractCategory("pet/1/cam/ptz/move")).isEqualTo("cam/ptz/move");
+    }
+
+    @Test
+    @DisplayName("잘못된 토픽 형식에서 예외 발생")
+    void invalidTopic() {
+        assertThatThrownBy(() -> MqttTopicManager.extractHouseId("invalid"))
+                .isInstanceOf(IllegalArgumentException.class);
+
+        assertThatThrownBy(() -> MqttTopicManager.extractCategory("pet/1"))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/src/test/java/com/capstone/pethouse/infra/mqtt/ack/MqttAckManagerTest.java
+++ b/src/test/java/com/capstone/pethouse/infra/mqtt/ack/MqttAckManagerTest.java
@@ -1,0 +1,91 @@
+package com.capstone.pethouse.infra.mqtt.ack;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MqttAckManagerTest {
+
+    @Test
+    @DisplayName("commandId 생성 시 유니크한 값 반환")
+    void generateUniqueCommandIds() {
+        MqttAckManager manager = new MqttAckManager();
+        String id1 = manager.generateCommandId();
+        String id2 = manager.generateCommandId();
+
+        assertThat(id1).isNotEqualTo(id2);
+        assertThat(id1).hasSize(8);
+    }
+
+    @Test
+    @DisplayName("ACK 등록 후 complete 호출 시 성공 결과 반환")
+    void registerAndComplete() throws Exception {
+        MqttAckManager manager = new MqttAckManager();
+        String commandId = manager.generateCommandId();
+
+        CompletableFuture<AckResult> future = manager.register(commandId);
+        assertThat(manager.pendingCount()).isEqualTo(1);
+
+        manager.complete(commandId, true, "OK");
+
+        AckResult result = future.get(1, TimeUnit.SECONDS);
+        assertThat(result.isSuccess()).isTrue();
+        assertThat(result.getMessage()).isEqualTo("OK");
+        assertThat(manager.pendingCount()).isZero();
+    }
+
+    @Test
+    @DisplayName("ACK 등록 후 실패 complete 호출 시 실패 결과 반환")
+    void registerAndCompleteFail() throws Exception {
+        MqttAckManager manager = new MqttAckManager();
+        String commandId = manager.generateCommandId();
+
+        CompletableFuture<AckResult> future = manager.register(commandId);
+        manager.complete(commandId, false, "Device busy");
+
+        AckResult result = future.get(1, TimeUnit.SECONDS);
+        assertThat(result.isSuccess()).isFalse();
+        assertThat(result.getMessage()).isEqualTo("Device busy");
+    }
+
+    @Test
+    @DisplayName("타임아웃 시 timeout 결과 반환")
+    void timeout() throws Exception {
+        MqttAckManager manager = new MqttAckManager();
+        String commandId = manager.generateCommandId();
+
+        CompletableFuture<AckResult> future = manager.register(commandId, 1); // 1초 타임아웃
+
+        AckResult result = future.get(3, TimeUnit.SECONDS);
+        assertThat(result.isSuccess()).isFalse();
+        assertThat(result.getMessage()).isEqualTo("ACK timeout");
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 commandId complete 시 무시")
+    void completeUnknown() {
+        MqttAckManager manager = new MqttAckManager();
+        // 예외 없이 무시되어야 함
+        manager.complete("unknown-id", true, "OK");
+        assertThat(manager.pendingCount()).isZero();
+    }
+
+    @Test
+    @DisplayName("AckResult 정적 팩토리 메서드")
+    void ackResultFactoryMethods() {
+        AckResult success = AckResult.success("done");
+        assertThat(success.isSuccess()).isTrue();
+        assertThat(success.getMessage()).isEqualTo("done");
+
+        AckResult failure = AckResult.failure("error");
+        assertThat(failure.isSuccess()).isFalse();
+
+        AckResult timeout = AckResult.timeout();
+        assertThat(timeout.isSuccess()).isFalse();
+        assertThat(timeout.getMessage()).isEqualTo("ACK timeout");
+    }
+}


### PR DESCRIPTION
- EMQX 브로커 Docker 설정 추가
- Spring Integration MQTT 연동 (MqttConfig, MqttProperties)
- MqttPublisher: 서버→기기 명령 발행
- MqttSubscriber: 기기→서버 데이터 수신 + 핸들러 라우팅
- MqttTopicManager: 토픽 체계 관리 (pet/{houseId}/sensor|device|cam)
- MqttAckManager: 비동기 ACK 대기 + 타임아웃 처리
- MqttCommandService: 명령 전송 + ACK 통합 서비스
- SecurityConfig 임시 설정 (permitAll, TASK-2에서 교체)
- 단위 테스트 12개 작성 (TopicManager, AckManager)