### PR TITLE
#41 feat: 시리얼/장치/코드 CRUD 24개 API 구현

### DIFF
--- a/src/main/java/com/capstone/pethouse/domain/code/controller/CodeController.java
+++ b/src/main/java/com/capstone/pethouse/domain/code/controller/CodeController.java
@@ -1,0 +1,70 @@
+package com.capstone.pethouse.domain.code.controller;
+
+import com.capstone.pethouse.domain.code.dto.CodeRequest;
+import com.capstone.pethouse.domain.code.dto.CodeVo;
+import com.capstone.pethouse.domain.code.service.CodeService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Map;
+
+@RequiredArgsConstructor
+@RequestMapping("/code")
+@RestController
+public class CodeController {
+
+    private final CodeService codeService;
+
+    @GetMapping("/list")
+    public ResponseEntity<Page<CodeVo>> list(
+            @RequestParam(defaultValue = "1") int pageNum,
+            @RequestParam(defaultValue = "15") int pageSize,
+            @RequestParam(name = "group_code", required = false) String groupCode) {
+        return ResponseEntity.ok(codeService.getCodes(pageNum, pageSize, groupCode));
+    }
+
+    @GetMapping("/tree")
+    public ResponseEntity<List<CodeVo>> tree(
+            @RequestParam(name = "group_code", required = false) String groupCode) {
+        return ResponseEntity.ok(codeService.getCodeTree(groupCode));
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<?> getCode(@PathVariable String id) {
+        try {
+            return ResponseEntity.ok(codeService.getCode(id));
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(Map.of("error", e.getMessage()));
+        }
+    }
+
+    @PostMapping
+    public ResponseEntity<?> createCode(@RequestBody CodeRequest request) {
+        try {
+            CodeVo response = codeService.createCode(request);
+            return ResponseEntity.status(HttpStatus.CREATED).body(response);
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.status(HttpStatus.CONFLICT).body(Map.of("error", e.getMessage()));
+        }
+    }
+
+    @PutMapping
+    public ResponseEntity<?> updateCode(@RequestBody CodeRequest request) {
+        try {
+            CodeVo response = codeService.updateCode(request);
+            return ResponseEntity.ok(response);
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().body(Map.of("error", e.getMessage()));
+        }
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteCode(@PathVariable String id) {
+        codeService.deleteCode(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/capstone/pethouse/domain/code/dto/CodeRequest.java
+++ b/src/main/java/com/capstone/pethouse/domain/code/dto/CodeRequest.java
@@ -1,0 +1,10 @@
+package com.capstone.pethouse.domain.code.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record CodeRequest(
+        String code,
+        @JsonProperty("group_code") String groupCode,
+        @JsonProperty("code_name") String codeName
+) {
+}

--- a/src/main/java/com/capstone/pethouse/domain/code/dto/CodeVo.java
+++ b/src/main/java/com/capstone/pethouse/domain/code/dto/CodeVo.java
@@ -1,0 +1,37 @@
+package com.capstone.pethouse.domain.code.dto;
+
+import com.capstone.pethouse.domain.code.entity.Code;
+
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+
+public record CodeVo(
+        String code,
+        String groupCode,
+        String codeName,
+        String regDate,
+        List<CodeVo> children
+) {
+    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+
+    public static CodeVo from(Code code) {
+        return new CodeVo(
+                code.getCode(),
+                code.getGroupCode(),
+                code.getCodeName(),
+                code.getRegDate().format(FORMATTER),
+                new ArrayList<>()
+        );
+    }
+
+    public static CodeVo withChildren(Code code, List<CodeVo> children) {
+        return new CodeVo(
+                code.getCode(),
+                code.getGroupCode(),
+                code.getCodeName(),
+                code.getRegDate().format(FORMATTER),
+                children
+        );
+    }
+}

--- a/src/main/java/com/capstone/pethouse/domain/code/entity/Code.java
+++ b/src/main/java/com/capstone/pethouse/domain/code/entity/Code.java
@@ -1,0 +1,60 @@
+package com.capstone.pethouse.domain.code.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+import java.util.Objects;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+@Table(name = "code")
+@Entity
+public class Code {
+
+    @Id
+    @Column(nullable = false, unique = true)
+    private String code;
+
+    @Column(nullable = false)
+    private String groupCode;
+
+    @Column(nullable = false)
+    private String codeName;
+
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime regDate;
+
+    private Code(String code, String groupCode, String codeName) {
+        this.code = code;
+        this.groupCode = groupCode;
+        this.codeName = codeName;
+    }
+
+    public static Code of(String code, String groupCode, String codeName) {
+        return new Code(code, groupCode, codeName);
+    }
+
+    public void update(String groupCode, String codeName) {
+        if (groupCode != null) this.groupCode = groupCode;
+        if (codeName != null) this.codeName = codeName;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Code that)) return false;
+        return Objects.equals(this.code, that.code);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(code);
+    }
+}

--- a/src/main/java/com/capstone/pethouse/domain/code/repository/CodeRepository.java
+++ b/src/main/java/com/capstone/pethouse/domain/code/repository/CodeRepository.java
@@ -1,0 +1,19 @@
+package com.capstone.pethouse.domain.code.repository;
+
+import com.capstone.pethouse.domain.code.entity.Code;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface CodeRepository extends JpaRepository<Code, String> {
+
+    List<Code> findByGroupCode(String groupCode);
+
+    Page<Code> findByGroupCode(String groupCode, Pageable pageable);
+
+    List<Code> findByGroupCodeOrCode(String groupCode, String code);
+}

--- a/src/main/java/com/capstone/pethouse/domain/code/service/CodeService.java
+++ b/src/main/java/com/capstone/pethouse/domain/code/service/CodeService.java
@@ -1,0 +1,103 @@
+package com.capstone.pethouse.domain.code.service;
+
+import com.capstone.pethouse.domain.code.dto.CodeRequest;
+import com.capstone.pethouse.domain.code.dto.CodeVo;
+import com.capstone.pethouse.domain.code.entity.Code;
+import com.capstone.pethouse.domain.code.repository.CodeRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@RequiredArgsConstructor
+@Service
+public class CodeService {
+
+    private final CodeRepository codeRepository;
+
+    @Transactional(readOnly = true)
+    public Page<CodeVo> getCodes(int pageNum, int pageSize, String groupCode) {
+        PageRequest pageRequest = PageRequest.of(pageNum - 1, pageSize, Sort.by(Sort.Direction.DESC, "regDate"));
+        if (groupCode != null && !groupCode.isBlank()) {
+            return codeRepository.findByGroupCode(groupCode, pageRequest).map(CodeVo::from);
+        }
+        return codeRepository.findAll(pageRequest).map(CodeVo::from);
+    }
+
+    @Transactional(readOnly = true)
+    public List<CodeVo> getCodeTree(String groupCode) {
+        List<Code> allCodes = codeRepository.findAll();
+
+        // 그룹코드가 빈 문자열인 것이 최상위 코드 (부모)
+        // 자식 코드는 groupCode가 부모의 code와 같은 것
+        Map<String, List<Code>> childrenMap = allCodes.stream()
+                .filter(c -> c.getGroupCode() != null && !c.getGroupCode().isEmpty())
+                .collect(Collectors.groupingBy(Code::getGroupCode));
+
+        List<Code> roots;
+        if (groupCode != null && !groupCode.isBlank()) {
+            roots = allCodes.stream()
+                    .filter(c -> c.getCode().equals(groupCode))
+                    .toList();
+        } else {
+            roots = allCodes.stream()
+                    .filter(c -> c.getGroupCode() == null || c.getGroupCode().isEmpty())
+                    .toList();
+        }
+
+        return roots.stream()
+                .map(root -> {
+                    List<CodeVo> children = childrenMap.getOrDefault(root.getCode(), List.of())
+                            .stream()
+                            .map(CodeVo::from)
+                            .toList();
+                    return CodeVo.withChildren(root, children);
+                })
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public CodeVo getCode(String id) {
+        Code code = codeRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("코드를 찾을 수 없습니다."));
+        return CodeVo.from(code);
+    }
+
+    @Transactional(readOnly = true)
+    public List<CodeVo> getCodesByGroupCode(String groupCode) {
+        return codeRepository.findByGroupCode(groupCode).stream()
+                .map(CodeVo::from)
+                .toList();
+    }
+
+    @Transactional
+    public CodeVo createCode(CodeRequest request) {
+        if (codeRepository.existsById(request.code())) {
+            throw new IllegalArgumentException("이미 존재하는 코드입니다.");
+        }
+        Code code = Code.of(request.code(), request.groupCode(), request.codeName());
+        return CodeVo.from(codeRepository.save(code));
+    }
+
+    @Transactional
+    public CodeVo updateCode(CodeRequest request) {
+        Code code = codeRepository.findById(request.code())
+                .orElseThrow(() -> new IllegalArgumentException("코드를 찾을 수 없습니다."));
+        code.update(request.groupCode(), request.codeName());
+        return CodeVo.from(code);
+    }
+
+    @Transactional
+    public void deleteCode(String id) {
+        if (!codeRepository.existsById(id)) {
+            throw new IllegalArgumentException("코드를 찾을 수 없습니다.");
+        }
+        codeRepository.deleteById(id);
+    }
+}

--- a/src/main/java/com/capstone/pethouse/domain/device/controller/DeviceController.java
+++ b/src/main/java/com/capstone/pethouse/domain/device/controller/DeviceController.java
@@ -1,0 +1,93 @@
+package com.capstone.pethouse.domain.device.controller;
+
+import com.capstone.pethouse.domain.code.dto.CodeVo;
+import com.capstone.pethouse.domain.code.service.CodeService;
+import com.capstone.pethouse.domain.device.dto.DeviceRequest;
+import com.capstone.pethouse.domain.device.dto.DeviceVo;
+import com.capstone.pethouse.domain.device.service.DeviceService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Map;
+
+@RequiredArgsConstructor
+@RequestMapping("/device")
+@RestController
+public class DeviceController {
+
+    private final DeviceService deviceService;
+    private final CodeService codeService;
+
+    @GetMapping("/list")
+    public ResponseEntity<Page<DeviceVo>> list(
+            @RequestParam(defaultValue = "1") int pageNum,
+            @RequestParam(defaultValue = "15") int pageSize,
+            @RequestParam(required = false) String searchType,
+            @RequestParam(required = false) String searchQuery) {
+        return ResponseEntity.ok(deviceService.getDevices(pageNum, pageSize, searchType, searchQuery));
+    }
+
+    @GetMapping("/{seq}")
+    public ResponseEntity<?> getDevice(@PathVariable Long seq) {
+        try {
+            return ResponseEntity.ok(deviceService.getDevice(seq));
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(Map.of("error", e.getMessage()));
+        }
+    }
+
+    @PostMapping
+    public ResponseEntity<?> createDevice(@RequestBody DeviceRequest request) {
+        try {
+            DeviceVo response = deviceService.createDevice(request);
+            return ResponseEntity.status(HttpStatus.CREATED).body(response);
+        } catch (IllegalArgumentException | IllegalStateException e) {
+            return ResponseEntity.badRequest().body(Map.of("error", e.getMessage()));
+        }
+    }
+
+    @PutMapping
+    public ResponseEntity<?> updateDevice(@RequestBody DeviceRequest request) {
+        try {
+            DeviceVo response = deviceService.updateDevice(request);
+            return ResponseEntity.ok(response);
+        } catch (IllegalArgumentException | IllegalStateException e) {
+            return ResponseEntity.badRequest().body(Map.of("error", e.getMessage()));
+        }
+    }
+
+    @DeleteMapping("/{seq}")
+    public ResponseEntity<Void> deleteDevice(@PathVariable Long seq) {
+        deviceService.deleteDevice(seq);
+        return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping("/popupList")
+    public ResponseEntity<List<Map<String, Object>>> getPopupList() {
+        return ResponseEntity.ok(deviceService.getPopupList());
+    }
+
+    @GetMapping("/popupListByType")
+    public ResponseEntity<List<Map<String, Object>>> getPopupListByType(@RequestParam String deviceType) {
+        return ResponseEntity.ok(deviceService.getPopupListByType(deviceType));
+    }
+
+    @GetMapping("/checkMember")
+    public ResponseEntity<Map<String, String>> checkMember(@RequestParam("member_id") String memberId) {
+        return ResponseEntity.ok(deviceService.checkMember(memberId));
+    }
+
+    @GetMapping("/checkSerial")
+    public ResponseEntity<Map<String, String>> checkSerial(@RequestParam("serial_num") String serialNum) {
+        return ResponseEntity.ok(deviceService.checkSerial(serialNum));
+    }
+
+    @GetMapping("/deviceTypeCodes")
+    public ResponseEntity<List<CodeVo>> getDeviceTypeCodes() {
+        return ResponseEntity.ok(codeService.getCodesByGroupCode("dtype"));
+    }
+}

--- a/src/main/java/com/capstone/pethouse/domain/device/dto/DeviceRequest.java
+++ b/src/main/java/com/capstone/pethouse/domain/device/dto/DeviceRequest.java
@@ -1,0 +1,15 @@
+package com.capstone.pethouse.domain.device.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record DeviceRequest(
+        Long seq,
+        @JsonProperty("device_id") String deviceId,
+        @JsonProperty("member_id") String memberId,
+        @JsonProperty("serial_num") String serialNum,
+        @JsonProperty("old_serial_num") String oldSerialNum,
+        @JsonProperty("object_code") String objectCode,
+        @JsonProperty("object_birth") String objectBirth,
+        @JsonProperty("device_type") String deviceType
+) {
+}

--- a/src/main/java/com/capstone/pethouse/domain/device/dto/DeviceVo.java
+++ b/src/main/java/com/capstone/pethouse/domain/device/dto/DeviceVo.java
@@ -1,0 +1,39 @@
+package com.capstone.pethouse.domain.device.dto;
+
+import com.capstone.pethouse.domain.device.entity.Device;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.time.format.DateTimeFormatter;
+
+public record DeviceVo(
+        Long seq,
+        String deviceId,
+        String memberId,
+        String serialNum,
+        String objectCode,
+        String objectName,
+        String deviceType,
+        String deviceTypeName,
+        String objectBirth,
+        @JsonProperty("isUse") boolean isUse,
+        String regDate
+) {
+    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+    private static final DateTimeFormatter DATETIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+
+    public static DeviceVo from(Device device) {
+        return new DeviceVo(
+                device.getSeq(),
+                device.getDeviceId(),
+                device.getMemberId(),
+                device.getSerialNum(),
+                device.getObjectCode(),
+                device.getObjectName(),
+                device.getDeviceType(),
+                device.getDeviceTypeName(),
+                device.getObjectBirth() != null ? device.getObjectBirth().format(DATE_FORMATTER) : null,
+                device.isUse(),
+                device.getRegDate().format(DATETIME_FORMATTER)
+        );
+    }
+}

--- a/src/main/java/com/capstone/pethouse/domain/device/entity/Device.java
+++ b/src/main/java/com/capstone/pethouse/domain/device/entity/Device.java
@@ -1,0 +1,92 @@
+package com.capstone.pethouse.domain.device.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Objects;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+@Table(name = "device")
+@Entity
+public class Device {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long seq;
+
+    @Column(nullable = false, unique = true)
+    private String deviceId;
+
+    @Column(nullable = false)
+    private String memberId;
+
+    @Column(nullable = false)
+    private String serialNum;
+
+    private String objectCode;
+
+    private String objectName;
+
+    @Column(nullable = false)
+    private String deviceType;
+
+    private String deviceTypeName;
+
+    private LocalDate objectBirth;
+
+    @Column(nullable = false)
+    private boolean isUse;
+
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime regDate;
+
+    private Device(String deviceId, String memberId, String serialNum,
+                   String objectCode, String objectName, String deviceType,
+                   String deviceTypeName, LocalDate objectBirth, boolean isUse) {
+        this.deviceId = deviceId;
+        this.memberId = memberId;
+        this.serialNum = serialNum;
+        this.objectCode = objectCode;
+        this.objectName = objectName;
+        this.deviceType = deviceType;
+        this.deviceTypeName = deviceTypeName;
+        this.objectBirth = objectBirth;
+        this.isUse = isUse;
+    }
+
+    public static Device of(String deviceId, String memberId, String serialNum,
+                             String objectCode, LocalDate objectBirth, String deviceType) {
+        return new Device(deviceId, memberId, serialNum, objectCode, null, deviceType, null, objectBirth, true);
+    }
+
+    public void update(String deviceId, String memberId, String serialNum,
+                       String objectCode, LocalDate objectBirth, String deviceType) {
+        if (deviceId != null) this.deviceId = deviceId;
+        if (memberId != null) this.memberId = memberId;
+        if (serialNum != null) this.serialNum = serialNum;
+        if (objectCode != null) this.objectCode = objectCode;
+        if (objectBirth != null) this.objectBirth = objectBirth;
+        if (deviceType != null) this.deviceType = deviceType;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Device that)) return false;
+        return this.seq != null && Objects.equals(this.seq, that.seq);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(seq);
+    }
+}

--- a/src/main/java/com/capstone/pethouse/domain/device/repository/DeviceRepository.java
+++ b/src/main/java/com/capstone/pethouse/domain/device/repository/DeviceRepository.java
@@ -1,0 +1,37 @@
+package com.capstone.pethouse.domain.device.repository;
+
+import com.capstone.pethouse.domain.device.entity.Device;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface DeviceRepository extends JpaRepository<Device, Long> {
+
+    Optional<Device> findBySerialNum(String serialNum);
+
+    boolean existsBySerialNum(String serialNum);
+
+    boolean existsByDeviceId(String deviceId);
+
+    @Query("SELECT d FROM Device d WHERE " +
+            "(:searchQuery IS NULL OR " +
+            " (:searchType = 'deviceId' AND d.deviceId LIKE %:searchQuery%) OR " +
+            " (:searchType = 'memberId' AND d.memberId LIKE %:searchQuery%) OR " +
+            " (:searchType = 'serialNum' AND d.serialNum LIKE %:searchQuery%) OR " +
+            " (:searchType IS NULL AND (d.deviceId LIKE %:searchQuery% OR d.memberId LIKE %:searchQuery% OR d.serialNum LIKE %:searchQuery%)))")
+    Page<Device> findAllWithSearch(@Param("searchType") String searchType,
+                                   @Param("searchQuery") String searchQuery,
+                                   Pageable pageable);
+
+    @Query("SELECT d FROM Device d")
+    List<Device> findAllPopupList();
+
+    List<Device> findByDeviceType(String deviceType);
+}

--- a/src/main/java/com/capstone/pethouse/domain/device/service/DeviceService.java
+++ b/src/main/java/com/capstone/pethouse/domain/device/service/DeviceService.java
@@ -1,0 +1,136 @@
+package com.capstone.pethouse.domain.device.service;
+
+import com.capstone.pethouse.domain.User.repository.UserRepository;
+import com.capstone.pethouse.domain.device.dto.DeviceRequest;
+import com.capstone.pethouse.domain.device.dto.DeviceVo;
+import com.capstone.pethouse.domain.device.entity.Device;
+import com.capstone.pethouse.domain.device.repository.DeviceRepository;
+import com.capstone.pethouse.domain.serial.entity.Serial;
+import com.capstone.pethouse.domain.serial.repository.SerialRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@RequiredArgsConstructor
+@Service
+public class DeviceService {
+
+    private final DeviceRepository deviceRepository;
+    private final SerialRepository serialRepository;
+    private final UserRepository userRepository;
+
+    @Transactional(readOnly = true)
+    public Page<DeviceVo> getDevices(int pageNum, int pageSize, String searchType, String searchQuery) {
+        PageRequest pageRequest = PageRequest.of(pageNum - 1, pageSize, Sort.by(Sort.Direction.DESC, "regDate"));
+        return deviceRepository.findAllWithSearch(searchType, searchQuery, pageRequest).map(DeviceVo::from);
+    }
+
+    @Transactional(readOnly = true)
+    public DeviceVo getDevice(Long seq) {
+        Device device = deviceRepository.findById(seq)
+                .orElseThrow(() -> new IllegalArgumentException("장치를 찾을 수 없습니다."));
+        return DeviceVo.from(device);
+    }
+
+    @Transactional
+    public DeviceVo createDevice(DeviceRequest request) {
+        Serial serial = serialRepository.findBySerialNum(request.serialNum())
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 시리얼 번호입니다."));
+        if (serial.isUse()) {
+            throw new IllegalStateException("이미 사용 중인 시리얼 번호입니다.");
+        }
+
+        LocalDate objectBirth = request.objectBirth() != null ? LocalDate.parse(request.objectBirth()) : null;
+        Device device = Device.of(
+                request.deviceId(), request.memberId(), request.serialNum(),
+                request.objectCode(), objectBirth, request.deviceType()
+        );
+
+        Device saved = deviceRepository.save(device);
+        serial.markUsed();
+        return DeviceVo.from(saved);
+    }
+
+    @Transactional
+    public DeviceVo updateDevice(DeviceRequest request) {
+        Device device = deviceRepository.findById(request.seq())
+                .orElseThrow(() -> new IllegalArgumentException("장치를 찾을 수 없습니다."));
+
+        // 시리얼 변경 처리
+        if (request.serialNum() != null && !request.serialNum().equals(device.getSerialNum())) {
+            // 기존 시리얼 미사용 처리
+            String oldSerialNum = request.oldSerialNum() != null ? request.oldSerialNum() : device.getSerialNum();
+            serialRepository.findBySerialNum(oldSerialNum).ifPresent(Serial::markUnused);
+
+            // 새 시리얼 검증 및 사용 처리
+            Serial newSerial = serialRepository.findBySerialNum(request.serialNum())
+                    .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 시리얼 번호입니다."));
+            if (newSerial.isUse()) {
+                throw new IllegalStateException("이미 사용 중인 시리얼 번호입니다.");
+            }
+            newSerial.markUsed();
+        }
+
+        LocalDate objectBirth = request.objectBirth() != null ? LocalDate.parse(request.objectBirth()) : null;
+        device.update(request.deviceId(), request.memberId(), request.serialNum(),
+                request.objectCode(), objectBirth, request.deviceType());
+
+        return DeviceVo.from(device);
+    }
+
+    @Transactional
+    public void deleteDevice(Long seq) {
+        Device device = deviceRepository.findById(seq)
+                .orElseThrow(() -> new IllegalArgumentException("장치를 찾을 수 없습니다."));
+
+        // 연결된 시리얼 미사용 처리
+        serialRepository.findBySerialNum(device.getSerialNum()).ifPresent(Serial::markUnused);
+
+        deviceRepository.delete(device);
+    }
+
+    @Transactional(readOnly = true)
+    public List<Map<String, Object>> getPopupList() {
+        return deviceRepository.findAllPopupList().stream()
+                .map(d -> {
+                    Map<String, Object> map = new LinkedHashMap<>();
+                    map.put("member_id", d.getMemberId());
+                    map.put("device_id", d.getDeviceId());
+                    return map;
+                })
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public List<Map<String, Object>> getPopupListByType(String deviceType) {
+        return deviceRepository.findByDeviceType(deviceType).stream()
+                .map(d -> {
+                    Map<String, Object> map = new LinkedHashMap<>();
+                    map.put("member_id", d.getMemberId());
+                    map.put("device_id", d.getDeviceId());
+                    return map;
+                })
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public Map<String, String> checkMember(String memberId) {
+        boolean exists = userRepository.existsByMemberId(memberId);
+        return Map.of("status", exists ? "ok" : "not_exist");
+    }
+
+    @Transactional(readOnly = true)
+    public Map<String, String> checkSerial(String serialNum) {
+        return serialRepository.findBySerialNum(serialNum)
+                .map(serial -> Map.of("status", serial.isUse() ? "in_use" : "ok"))
+                .orElse(Map.of("status", "not_exist"));
+    }
+}

--- a/src/main/java/com/capstone/pethouse/domain/serial/controller/SerialController.java
+++ b/src/main/java/com/capstone/pethouse/domain/serial/controller/SerialController.java
@@ -1,0 +1,98 @@
+package com.capstone.pethouse.domain.serial.controller;
+
+import com.capstone.pethouse.domain.serial.dto.SerialRequest;
+import com.capstone.pethouse.domain.serial.dto.SerialVo;
+import com.capstone.pethouse.domain.serial.service.SerialService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Map;
+
+@RequiredArgsConstructor
+@RequestMapping("/serial")
+@RestController
+public class SerialController {
+
+    private final SerialService serialService;
+
+    @GetMapping("/list")
+    public ResponseEntity<Page<SerialVo>> list(
+            @RequestParam(defaultValue = "1") int pageNum,
+            @RequestParam(defaultValue = "15") int pageSize,
+            @RequestParam(required = false) String searchQuery) {
+        return ResponseEntity.ok(serialService.getSerials(pageNum, pageSize, searchQuery));
+    }
+
+    @GetMapping("/{seq}")
+    public ResponseEntity<?> getSerial(@PathVariable Long seq) {
+        try {
+            return ResponseEntity.ok(serialService.getSerial(seq));
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(Map.of("error", e.getMessage()));
+        }
+    }
+
+    @PostMapping("/add")
+    public ResponseEntity<?> addSerial(@RequestBody SerialRequest request) {
+        try {
+            String message = serialService.addSerial(request);
+            return ResponseEntity.status(HttpStatus.CREATED).body(message);
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().body(e.getMessage());
+        }
+    }
+
+    @PutMapping("/update")
+    public ResponseEntity<?> updateSerial(@RequestBody SerialRequest request) {
+        try {
+            String message = serialService.updateSerial(request);
+            return ResponseEntity.ok(message);
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().body("수정 실패: " + e.getMessage());
+        }
+    }
+
+    @DeleteMapping("/delete/{seq}")
+    public ResponseEntity<?> deleteSerial(@PathVariable Long seq) {
+        try {
+            String message = serialService.deleteSerial(seq);
+            return ResponseEntity.ok(message);
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
+        }
+    }
+
+    @PutMapping("/use/{serialNum}")
+    public ResponseEntity<?> markAsUsed(@PathVariable String serialNum) {
+        try {
+            String message = serialService.markAsUsed(serialNum);
+            return ResponseEntity.ok(message);
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
+        }
+    }
+
+    @PutMapping("/release/{serialNum}")
+    public ResponseEntity<?> markAsUnused(@PathVariable String serialNum) {
+        try {
+            String message = serialService.markAsUnused(serialNum);
+            return ResponseEntity.ok(message);
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
+        }
+    }
+
+    @PostMapping("/generate")
+    public ResponseEntity<?> generateSerials(@RequestParam int count) {
+        try {
+            List<SerialVo> result = serialService.generateSerials(count);
+            return ResponseEntity.status(HttpStatus.CREATED).body(result);
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(Map.of("error", e.getMessage()));
+        }
+    }
+}

--- a/src/main/java/com/capstone/pethouse/domain/serial/dto/SerialRequest.java
+++ b/src/main/java/com/capstone/pethouse/domain/serial/dto/SerialRequest.java
@@ -1,0 +1,10 @@
+package com.capstone.pethouse.domain.serial.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record SerialRequest(
+        Long seq,
+        String serialNum,
+        @JsonProperty("isUse") Boolean isUse
+) {
+}

--- a/src/main/java/com/capstone/pethouse/domain/serial/dto/SerialVo.java
+++ b/src/main/java/com/capstone/pethouse/domain/serial/dto/SerialVo.java
@@ -1,0 +1,24 @@
+package com.capstone.pethouse.domain.serial.dto;
+
+import com.capstone.pethouse.domain.serial.entity.Serial;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.time.format.DateTimeFormatter;
+
+public record SerialVo(
+        Long seq,
+        String serialNum,
+        @JsonProperty("isUse") boolean isUse,
+        String regDate
+) {
+    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+
+    public static SerialVo from(Serial serial) {
+        return new SerialVo(
+                serial.getSeq(),
+                serial.getSerialNum(),
+                serial.isUse(),
+                serial.getRegDate().format(FORMATTER)
+        );
+    }
+}

--- a/src/main/java/com/capstone/pethouse/domain/serial/entity/Serial.java
+++ b/src/main/java/com/capstone/pethouse/domain/serial/entity/Serial.java
@@ -1,0 +1,67 @@
+package com.capstone.pethouse.domain.serial.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+import java.util.Objects;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+@Table(name = "serial")
+@Entity
+public class Serial {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long seq;
+
+    @Column(nullable = false, unique = true)
+    private String serialNum;
+
+    @Column(nullable = false)
+    private boolean isUse;
+
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime regDate;
+
+    private Serial(String serialNum, boolean isUse) {
+        this.serialNum = serialNum;
+        this.isUse = isUse;
+    }
+
+    public static Serial of(String serialNum, boolean isUse) {
+        return new Serial(serialNum, isUse);
+    }
+
+    public void update(String serialNum, boolean isUse) {
+        if (serialNum != null) this.serialNum = serialNum;
+        this.isUse = isUse;
+    }
+
+    public void markUsed() {
+        this.isUse = true;
+    }
+
+    public void markUnused() {
+        this.isUse = false;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Serial that)) return false;
+        return this.seq != null && Objects.equals(this.seq, that.seq);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(seq);
+    }
+}

--- a/src/main/java/com/capstone/pethouse/domain/serial/repository/SerialRepository.java
+++ b/src/main/java/com/capstone/pethouse/domain/serial/repository/SerialRepository.java
@@ -1,0 +1,23 @@
+package com.capstone.pethouse.domain.serial.repository;
+
+import com.capstone.pethouse.domain.serial.entity.Serial;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface SerialRepository extends JpaRepository<Serial, Long> {
+
+    Optional<Serial> findBySerialNum(String serialNum);
+
+    boolean existsBySerialNum(String serialNum);
+
+    @Query("SELECT s FROM Serial s WHERE " +
+            "(:searchQuery IS NULL OR s.serialNum LIKE %:searchQuery%)")
+    Page<Serial> findAllWithSearch(@Param("searchQuery") String searchQuery, Pageable pageable);
+}

--- a/src/main/java/com/capstone/pethouse/domain/serial/service/SerialService.java
+++ b/src/main/java/com/capstone/pethouse/domain/serial/service/SerialService.java
@@ -1,0 +1,105 @@
+package com.capstone.pethouse.domain.serial.service;
+
+import com.capstone.pethouse.domain.serial.dto.SerialRequest;
+import com.capstone.pethouse.domain.serial.dto.SerialVo;
+import com.capstone.pethouse.domain.serial.entity.Serial;
+import com.capstone.pethouse.domain.serial.repository.SerialRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+
+@RequiredArgsConstructor
+@Service
+public class SerialService {
+
+    private final SerialRepository serialRepository;
+
+    @Transactional(readOnly = true)
+    public Page<SerialVo> getSerials(int pageNum, int pageSize, String searchQuery) {
+        PageRequest pageRequest = PageRequest.of(pageNum - 1, pageSize, Sort.by(Sort.Direction.DESC, "regDate"));
+        return serialRepository.findAllWithSearch(searchQuery, pageRequest).map(SerialVo::from);
+    }
+
+    @Transactional(readOnly = true)
+    public SerialVo getSerial(Long seq) {
+        Serial serial = serialRepository.findById(seq)
+                .orElseThrow(() -> new IllegalArgumentException("시리얼을 찾을 수 없습니다."));
+        return SerialVo.from(serial);
+    }
+
+    @Transactional
+    public String addSerial(SerialRequest request) {
+        if (serialRepository.existsBySerialNum(request.serialNum())) {
+            throw new IllegalArgumentException("이미 존재하는 시리얼 번호입니다.");
+        }
+        boolean isUse = request.isUse() != null ? request.isUse() : false;
+        serialRepository.save(Serial.of(request.serialNum(), isUse));
+        return "등록 성공";
+    }
+
+    @Transactional
+    public String updateSerial(SerialRequest request) {
+        Serial serial = serialRepository.findById(request.seq())
+                .orElseThrow(() -> new IllegalArgumentException("시리얼을 찾을 수 없습니다."));
+
+        if (request.serialNum() != null && !request.serialNum().equals(serial.getSerialNum())) {
+            if (serialRepository.existsBySerialNum(request.serialNum())) {
+                throw new IllegalArgumentException("이미 존재하는 시리얼 번호입니다.");
+            }
+        }
+
+        boolean isUse = request.isUse() != null ? request.isUse() : serial.isUse();
+        serial.update(request.serialNum(), isUse);
+        return "수정 성공";
+    }
+
+    @Transactional
+    public String deleteSerial(Long seq) {
+        if (!serialRepository.existsById(seq)) {
+            throw new IllegalArgumentException("시리얼을 찾을 수 없습니다.");
+        }
+        serialRepository.deleteById(seq);
+        return "삭제 성공";
+    }
+
+    @Transactional
+    public String markAsUsed(String serialNum) {
+        Serial serial = serialRepository.findBySerialNum(serialNum)
+                .orElseThrow(() -> new IllegalArgumentException("시리얼을 찾을 수 없습니다."));
+        serial.markUsed();
+        return "사용 처리 완료";
+    }
+
+    @Transactional
+    public String markAsUnused(String serialNum) {
+        Serial serial = serialRepository.findBySerialNum(serialNum)
+                .orElseThrow(() -> new IllegalArgumentException("시리얼을 찾을 수 없습니다."));
+        serial.markUnused();
+        return "미사용 처리 완료";
+    }
+
+    @Transactional
+    public List<SerialVo> generateSerials(int count) {
+        String datePrefix = LocalDate.now().format(DateTimeFormatter.ofPattern("yyyyMMdd"));
+        List<SerialVo> result = new ArrayList<>();
+
+        for (int i = 0; i < count; i++) {
+            String serialNum;
+            do {
+                serialNum = datePrefix + "-DEV-" + String.format("%03d", (int) (Math.random() * 1000));
+            } while (serialRepository.existsBySerialNum(serialNum));
+
+            Serial serial = serialRepository.save(Serial.of(serialNum, false));
+            result.add(SerialVo.from(serial));
+        }
+        return result;
+    }
+}

--- a/src/main/java/com/capstone/pethouse/global/config/SecurityConfig.java
+++ b/src/main/java/com/capstone/pethouse/global/config/SecurityConfig.java
@@ -41,6 +41,8 @@ public class SecurityConfig {
                         .requestMatchers("/member/register").permitAll()
                         .requestMatchers("/member/checkId").permitAll()
                         .requestMatchers("/member/find-id", "/member/verify-user", "/member/reset-password").permitAll()
+                        .requestMatchers("/device/checkMember", "/device/checkSerial").permitAll()
+                        .requestMatchers("/device/deviceTypeCodes").permitAll()
                         .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                         .anyRequest().authenticated()
                 )


### PR DESCRIPTION
- Serial 도메인: 시리얼 CRUD + 사용/미사용 처리 + 자동생성 (8개 API)
- Device 도메인: 장치 CRUD + 팝업 목록 + 회원/시리얼 검증 (10개 API)
- Code 도메인: 코드 CRUD + 트리 조회 (6개 API)
- SecurityConfig: checkMember, checkSerial, deviceTypeCodes 퍼밋 추가