### PR TITLE
[#56] TASK-4 Sensor 데이터 + 파일(오디오) CRUD 18개 API 구현

### DIFF
--- a/src/main/java/com/capstone/pethouse/domain/file/controller/FileController.java
+++ b/src/main/java/com/capstone/pethouse/domain/file/controller/FileController.java
@@ -1,0 +1,106 @@
+package com.capstone.pethouse.domain.file.controller;
+
+import com.capstone.pethouse.domain.file.dto.FileResultResponse;
+import com.capstone.pethouse.domain.file.dto.FileVo;
+import com.capstone.pethouse.domain.file.entity.FileInfo;
+import com.capstone.pethouse.domain.file.service.FileService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.io.Resource;
+import org.springframework.data.domain.Page;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+@RequiredArgsConstructor
+@RequestMapping("/file")
+@RestController
+public class FileController {
+
+    private final FileService fileService;
+
+    @GetMapping("/list")
+    public ResponseEntity<Page<FileVo>> list(
+            @RequestParam(defaultValue = "1") int pageNum,
+            @RequestParam(defaultValue = "15") int pageSize,
+            @RequestParam(required = false) String deviceId,
+            @RequestParam(required = false) String searchQuery) {
+        return ResponseEntity.ok(fileService.getList(pageNum, pageSize, deviceId, searchQuery));
+    }
+
+    @GetMapping("/{seq}")
+    public ResponseEntity<FileVo> get(@PathVariable Long seq,
+                                       @RequestParam(required = false) String deviceId) {
+        return ResponseEntity.ok(fileService.get(seq, deviceId));
+    }
+
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<FileResultResponse> upload(
+            @RequestParam String deviceId,
+            @RequestParam(required = false) String filename,
+            @RequestPart("file") MultipartFile file) {
+        try {
+            fileService.upload(deviceId, filename, file);
+            return ResponseEntity.ok(FileResultResponse.ok("입력 완료"));
+        } catch (Exception e) {
+            return ResponseEntity.badRequest().body(FileResultResponse.fail(e.getMessage()));
+        }
+    }
+
+    @PutMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<FileResultResponse> update(
+            @RequestParam Long seq,
+            @RequestParam String deviceId,
+            @RequestParam(required = false) String filename,
+            @RequestPart(value = "file", required = false) MultipartFile file) {
+        try {
+            fileService.updateFile(seq, deviceId, filename, file);
+            return ResponseEntity.ok(FileResultResponse.ok("파일이 수정되었습니다."));
+        } catch (Exception e) {
+            return ResponseEntity.badRequest().body(FileResultResponse.fail(e.getMessage()));
+        }
+    }
+
+    @DeleteMapping
+    public ResponseEntity<FileResultResponse> delete(@RequestBody Map<String, Object> body) {
+        try {
+            Long seq = Long.valueOf(body.get("seq").toString());
+            String deviceId = body.get("deviceId") != null ? body.get("deviceId").toString() : null;
+            fileService.delete(seq, deviceId);
+            return ResponseEntity.ok(FileResultResponse.ok("삭제 완료"));
+        } catch (Exception e) {
+            return ResponseEntity.badRequest().body(FileResultResponse.fail(e.getMessage()));
+        }
+    }
+
+    @GetMapping("/audio/{seq}")
+    public ResponseEntity<Resource> streamAudio(@PathVariable Long seq,
+                                                 @RequestParam(required = false) String deviceId) {
+        FileInfo info = fileService.getEntity(seq, deviceId);
+        Resource resource = fileService.loadAsResource(seq, deviceId);
+
+        String contentType = info.getContentType() != null ? info.getContentType() : "audio/mpeg";
+        return ResponseEntity.ok()
+                .contentType(MediaType.parseMediaType(contentType))
+                .header(HttpHeaders.CONTENT_DISPOSITION, "inline; filename=\"" + info.getFilename() + "\"")
+                .body(resource);
+    }
+
+    @GetMapping("/download/{seq}")
+    public ResponseEntity<Resource> download(@PathVariable Long seq,
+                                              @RequestParam(required = false) String deviceId) {
+        FileInfo info = fileService.getEntity(seq, deviceId);
+        Resource resource = fileService.loadAsResource(seq, deviceId);
+
+        String encoded = URLEncoder.encode(info.getFilename(), StandardCharsets.UTF_8).replace("+", "%20");
+        return ResponseEntity.ok()
+                .contentType(MediaType.APPLICATION_OCTET_STREAM)
+                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + encoded + "\"")
+                .body(resource);
+    }
+}

--- a/src/main/java/com/capstone/pethouse/domain/file/dto/FileResultResponse.java
+++ b/src/main/java/com/capstone/pethouse/domain/file/dto/FileResultResponse.java
@@ -1,0 +1,11 @@
+package com.capstone.pethouse.domain.file.dto;
+
+public record FileResultResponse(boolean result, String message) {
+    public static FileResultResponse ok(String message) {
+        return new FileResultResponse(true, message);
+    }
+
+    public static FileResultResponse fail(String message) {
+        return new FileResultResponse(false, message);
+    }
+}

--- a/src/main/java/com/capstone/pethouse/domain/file/dto/FileVo.java
+++ b/src/main/java/com/capstone/pethouse/domain/file/dto/FileVo.java
@@ -1,0 +1,23 @@
+package com.capstone.pethouse.domain.file.dto;
+
+import com.capstone.pethouse.domain.file.entity.FileInfo;
+
+import java.time.format.DateTimeFormatter;
+
+public record FileVo(
+        Long seq,
+        String deviceId,
+        String filename,
+        String regDate
+) {
+    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+
+    public static FileVo from(FileInfo f) {
+        return new FileVo(
+                f.getSeq(),
+                f.getDeviceId(),
+                f.getFilename(),
+                f.getRegDate().format(FORMATTER)
+        );
+    }
+}

--- a/src/main/java/com/capstone/pethouse/domain/file/entity/FileInfo.java
+++ b/src/main/java/com/capstone/pethouse/domain/file/entity/FileInfo.java
@@ -1,0 +1,74 @@
+package com.capstone.pethouse.domain.file.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+import java.util.Objects;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+@Table(name = "file_info", indexes = {
+        @Index(name = "idx_file_info_device_id", columnList = "deviceId")
+})
+@Entity
+public class FileInfo {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long seq;
+
+    @Column(nullable = false)
+    private String deviceId;
+
+    @Column(nullable = false)
+    private String filename;
+
+    @Column(nullable = false, length = 500)
+    private String filePath;
+
+    private String contentType;
+
+    private Long fileSize;
+
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime regDate;
+
+    private FileInfo(String deviceId, String filename, String filePath, String contentType, Long fileSize) {
+        this.deviceId = deviceId;
+        this.filename = filename;
+        this.filePath = filePath;
+        this.contentType = contentType;
+        this.fileSize = fileSize;
+    }
+
+    public static FileInfo of(String deviceId, String filename, String filePath, String contentType, Long fileSize) {
+        return new FileInfo(deviceId, filename, filePath, contentType, fileSize);
+    }
+
+    public void update(String deviceId, String filename, String filePath, String contentType, Long fileSize) {
+        if (deviceId != null) this.deviceId = deviceId;
+        if (filename != null) this.filename = filename;
+        if (filePath != null) this.filePath = filePath;
+        if (contentType != null) this.contentType = contentType;
+        if (fileSize != null) this.fileSize = fileSize;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof FileInfo that)) return false;
+        return this.seq != null && Objects.equals(this.seq, that.seq);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(seq);
+    }
+}

--- a/src/main/java/com/capstone/pethouse/domain/file/repository/FileRepository.java
+++ b/src/main/java/com/capstone/pethouse/domain/file/repository/FileRepository.java
@@ -1,0 +1,25 @@
+package com.capstone.pethouse.domain.file.repository;
+
+import com.capstone.pethouse.domain.file.entity.FileInfo;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface FileRepository extends JpaRepository<FileInfo, Long> {
+
+    Optional<FileInfo> findBySeqAndDeviceId(Long seq, String deviceId);
+
+    @Query("SELECT f FROM FileInfo f WHERE " +
+            "(:deviceId IS NULL OR :deviceId = '' OR f.deviceId = :deviceId) AND " +
+            "(:searchQuery IS NULL OR :searchQuery = '' OR f.filename LIKE %:searchQuery% OR f.deviceId LIKE %:searchQuery%) " +
+            "ORDER BY f.regDate DESC")
+    Page<FileInfo> findAllWithSearch(@Param("deviceId") String deviceId,
+                                      @Param("searchQuery") String searchQuery,
+                                      Pageable pageable);
+}

--- a/src/main/java/com/capstone/pethouse/domain/file/service/FileService.java
+++ b/src/main/java/com/capstone/pethouse/domain/file/service/FileService.java
@@ -1,0 +1,146 @@
+package com.capstone.pethouse.domain.file.service;
+
+import com.capstone.pethouse.domain.file.dto.FileVo;
+import com.capstone.pethouse.domain.file.entity.FileInfo;
+import com.capstone.pethouse.domain.file.repository.FileRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.UrlResource;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.util.UUID;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class FileService {
+
+    private final FileRepository fileRepository;
+
+    @Value("${file.upload-dir:./uploads}")
+    private String uploadDir;
+
+    @Transactional(readOnly = true)
+    public Page<FileVo> getList(int pageNum, int pageSize, String deviceId, String searchQuery) {
+        PageRequest pageRequest = PageRequest.of(Math.max(pageNum - 1, 0), pageSize);
+        return fileRepository.findAllWithSearch(deviceId, searchQuery, pageRequest).map(FileVo::from);
+    }
+
+    @Transactional(readOnly = true)
+    public FileVo get(Long seq, String deviceId) {
+        FileInfo file = findOne(seq, deviceId);
+        return FileVo.from(file);
+    }
+
+    @Transactional
+    public FileInfo upload(String deviceId, String filename, MultipartFile multipartFile) throws IOException {
+        if (deviceId == null || deviceId.isBlank()) {
+            throw new IllegalArgumentException("deviceId는 필수입니다.");
+        }
+        if (multipartFile == null || multipartFile.isEmpty()) {
+            throw new IllegalArgumentException("file은 필수입니다.");
+        }
+
+        String storedFilename = UUID.randomUUID() + "_" + (filename != null ? filename : multipartFile.getOriginalFilename());
+        Path destPath = ensureUploadDir().resolve(storedFilename);
+        Files.copy(multipartFile.getInputStream(), destPath, StandardCopyOption.REPLACE_EXISTING);
+
+        FileInfo info = FileInfo.of(
+                deviceId,
+                filename != null ? filename : multipartFile.getOriginalFilename(),
+                destPath.toAbsolutePath().toString(),
+                multipartFile.getContentType(),
+                multipartFile.getSize()
+        );
+        return fileRepository.save(info);
+    }
+
+    @Transactional
+    public FileInfo updateFile(Long seq, String deviceId, String filename, MultipartFile multipartFile) throws IOException {
+        FileInfo file = findOne(seq, deviceId);
+
+        String newPath = file.getFilePath();
+        String newContentType = file.getContentType();
+        Long newSize = file.getFileSize();
+
+        if (multipartFile != null && !multipartFile.isEmpty()) {
+            // 기존 파일 삭제
+            try {
+                Files.deleteIfExists(Paths.get(file.getFilePath()));
+            } catch (IOException e) {
+                log.warn("기존 파일 삭제 실패: {}", file.getFilePath());
+            }
+
+            String storedFilename = UUID.randomUUID() + "_" + (filename != null ? filename : multipartFile.getOriginalFilename());
+            Path destPath = ensureUploadDir().resolve(storedFilename);
+            Files.copy(multipartFile.getInputStream(), destPath, StandardCopyOption.REPLACE_EXISTING);
+
+            newPath = destPath.toAbsolutePath().toString();
+            newContentType = multipartFile.getContentType();
+            newSize = multipartFile.getSize();
+        }
+
+        file.update(deviceId, filename, newPath, newContentType, newSize);
+        return file;
+    }
+
+    @Transactional
+    public void delete(Long seq, String deviceId) {
+        FileInfo file = findOne(seq, deviceId);
+        try {
+            Files.deleteIfExists(Paths.get(file.getFilePath()));
+        } catch (IOException e) {
+            log.warn("파일 삭제 실패: {}", file.getFilePath());
+        }
+        fileRepository.delete(file);
+    }
+
+    @Transactional(readOnly = true)
+    public Resource loadAsResource(Long seq, String deviceId) {
+        FileInfo file = findOne(seq, deviceId);
+        try {
+            Path path = Paths.get(file.getFilePath());
+            Resource resource = new UrlResource(path.toUri());
+            if (!resource.exists() || !resource.isReadable()) {
+                throw new IllegalStateException("파일을 읽을 수 없습니다: " + file.getFilename());
+            }
+            return resource;
+        } catch (MalformedURLException e) {
+            throw new IllegalStateException("파일 경로가 올바르지 않습니다.", e);
+        }
+    }
+
+    @Transactional(readOnly = true)
+    public FileInfo getEntity(Long seq, String deviceId) {
+        return findOne(seq, deviceId);
+    }
+
+    private FileInfo findOne(Long seq, String deviceId) {
+        if (deviceId != null && !deviceId.isBlank()) {
+            return fileRepository.findBySeqAndDeviceId(seq, deviceId)
+                    .orElseThrow(() -> new IllegalArgumentException("파일을 찾을 수 없습니다."));
+        }
+        return fileRepository.findById(seq)
+                .orElseThrow(() -> new IllegalArgumentException("파일을 찾을 수 없습니다."));
+    }
+
+    private Path ensureUploadDir() throws IOException {
+        Path dir = Paths.get(uploadDir);
+        if (!Files.exists(dir)) {
+            Files.createDirectories(dir);
+        }
+        return dir;
+    }
+}

--- a/src/main/java/com/capstone/pethouse/domain/sensor/controller/ChartController.java
+++ b/src/main/java/com/capstone/pethouse/domain/sensor/controller/ChartController.java
@@ -1,0 +1,25 @@
+package com.capstone.pethouse.domain.sensor.controller;
+
+import com.capstone.pethouse.domain.sensor.dto.DataVo;
+import com.capstone.pethouse.domain.sensor.service.ChartService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@RequestMapping("/data/chart")
+@RestController
+public class ChartController {
+
+    private final ChartService chartService;
+
+    @GetMapping
+    public ResponseEntity<List<DataVo>> getChart(@RequestParam String serialNum) {
+        return ResponseEntity.ok(chartService.getChartData(serialNum));
+    }
+}

--- a/src/main/java/com/capstone/pethouse/domain/sensor/controller/HouseDataController.java
+++ b/src/main/java/com/capstone/pethouse/domain/sensor/controller/HouseDataController.java
@@ -1,0 +1,53 @@
+package com.capstone.pethouse.domain.sensor.controller;
+
+import com.capstone.pethouse.domain.sensor.dto.DataVo;
+import com.capstone.pethouse.domain.sensor.dto.HouseDataRequest;
+import com.capstone.pethouse.domain.sensor.service.HouseDataService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RequiredArgsConstructor
+@RequestMapping("/data/house")
+@RestController
+public class HouseDataController {
+
+    private final HouseDataService houseDataService;
+
+    @GetMapping("/list")
+    public ResponseEntity<Page<DataVo>> list(
+            @RequestParam(defaultValue = "1") int pageNum,
+            @RequestParam(defaultValue = "15") int pageSize,
+            @RequestParam(required = false) String searchQuery) {
+        return ResponseEntity.ok(houseDataService.getList(pageNum, pageSize, searchQuery));
+    }
+
+    @GetMapping("/{seq}")
+    public ResponseEntity<DataVo> get(@PathVariable Long seq) {
+        return ResponseEntity.ok(houseDataService.get(seq));
+    }
+
+    @PostMapping
+    public ResponseEntity<String> create(@RequestBody HouseDataRequest request) {
+        houseDataService.create(request);
+        return ResponseEntity.status(HttpStatus.CREATED).body("등록 및 알림 처리 완료");
+    }
+
+    @PutMapping("/{seq}")
+    public ResponseEntity<String> update(@PathVariable Long seq, @RequestBody HouseDataRequest request) {
+        try {
+            houseDataService.update(seq, request);
+            return ResponseEntity.ok("수정되었습니다.");
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().body("수정 실패");
+        }
+    }
+
+    @DeleteMapping("/{seq}")
+    public ResponseEntity<String> delete(@PathVariable Long seq) {
+        houseDataService.delete(seq);
+        return ResponseEntity.ok("삭제되었습니다.");
+    }
+}

--- a/src/main/java/com/capstone/pethouse/domain/sensor/controller/NeckDataController.java
+++ b/src/main/java/com/capstone/pethouse/domain/sensor/controller/NeckDataController.java
@@ -1,0 +1,53 @@
+package com.capstone.pethouse.domain.sensor.controller;
+
+import com.capstone.pethouse.domain.sensor.dto.DataVo;
+import com.capstone.pethouse.domain.sensor.dto.NeckDataRequest;
+import com.capstone.pethouse.domain.sensor.service.NeckDataService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RequiredArgsConstructor
+@RequestMapping("/data/neck")
+@RestController
+public class NeckDataController {
+
+    private final NeckDataService neckDataService;
+
+    @GetMapping("/list")
+    public ResponseEntity<Page<DataVo>> list(
+            @RequestParam(defaultValue = "1") int pageNum,
+            @RequestParam(defaultValue = "15") int pageSize,
+            @RequestParam(required = false) String searchQuery) {
+        return ResponseEntity.ok(neckDataService.getList(pageNum, pageSize, searchQuery));
+    }
+
+    @GetMapping("/{seq}")
+    public ResponseEntity<DataVo> get(@PathVariable Long seq) {
+        return ResponseEntity.ok(neckDataService.get(seq));
+    }
+
+    @PostMapping
+    public ResponseEntity<String> create(@RequestBody NeckDataRequest request) {
+        neckDataService.create(request);
+        return ResponseEntity.status(HttpStatus.CREATED).body("등록 및 알림 처리 완료");
+    }
+
+    @PutMapping("/{seq}")
+    public ResponseEntity<String> update(@PathVariable Long seq, @RequestBody NeckDataRequest request) {
+        try {
+            neckDataService.update(seq, request);
+            return ResponseEntity.ok("수정되었습니다.");
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().body("수정 실패");
+        }
+    }
+
+    @DeleteMapping("/{seq}")
+    public ResponseEntity<String> delete(@PathVariable Long seq) {
+        neckDataService.delete(seq);
+        return ResponseEntity.ok("삭제되었습니다.");
+    }
+}

--- a/src/main/java/com/capstone/pethouse/domain/sensor/dto/DataVo.java
+++ b/src/main/java/com/capstone/pethouse/domain/sensor/dto/DataVo.java
@@ -1,0 +1,42 @@
+package com.capstone.pethouse.domain.sensor.dto;
+
+import com.capstone.pethouse.domain.sensor.entity.HouseData;
+import com.capstone.pethouse.domain.sensor.entity.NeckData;
+
+import java.time.format.DateTimeFormatter;
+
+public record DataVo(
+        Long seq,
+        String deviceId,
+        Double temVal,
+        Double humVal,
+        Double heartVal,
+        Double coVal,
+        String regDate
+) {
+    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyyyMMddHHmmss");
+
+    public static DataVo fromHouse(HouseData h) {
+        return new DataVo(
+                h.getSeq(),
+                h.getDeviceId(),
+                h.getTemVal(),
+                h.getHumVal(),
+                null,
+                h.getCoVal(),
+                h.getRegDate().format(FORMATTER)
+        );
+    }
+
+    public static DataVo fromNeck(NeckData n) {
+        return new DataVo(
+                n.getSeq(),
+                n.getDeviceId(),
+                n.getTemVal(),
+                null,
+                n.getHeartVal(),
+                n.getCoVal(),
+                n.getRegDate().format(FORMATTER)
+        );
+    }
+}

--- a/src/main/java/com/capstone/pethouse/domain/sensor/dto/HouseDataRequest.java
+++ b/src/main/java/com/capstone/pethouse/domain/sensor/dto/HouseDataRequest.java
@@ -1,0 +1,11 @@
+package com.capstone.pethouse.domain.sensor.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record HouseDataRequest(
+        @JsonProperty("device_id") String deviceId,
+        @JsonProperty("tem_val") Double temVal,
+        @JsonProperty("hum_val") Double humVal,
+        @JsonProperty("co_val") Double coVal
+) {
+}

--- a/src/main/java/com/capstone/pethouse/domain/sensor/dto/NeckDataRequest.java
+++ b/src/main/java/com/capstone/pethouse/domain/sensor/dto/NeckDataRequest.java
@@ -1,0 +1,11 @@
+package com.capstone.pethouse.domain.sensor.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record NeckDataRequest(
+        @JsonProperty("device_id") String deviceId,
+        @JsonProperty("tem_val") Double temVal,
+        @JsonProperty("heart_val") Double heartVal,
+        @JsonProperty("co_val") Double coVal
+) {
+}

--- a/src/main/java/com/capstone/pethouse/domain/sensor/entity/HouseData.java
+++ b/src/main/java/com/capstone/pethouse/domain/sensor/entity/HouseData.java
@@ -1,0 +1,69 @@
+package com.capstone.pethouse.domain.sensor.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+import java.util.Objects;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+@Table(name = "house_data", indexes = {
+        @Index(name = "idx_house_data_device_id", columnList = "deviceId"),
+        @Index(name = "idx_house_data_reg_date", columnList = "regDate")
+})
+@Entity
+public class HouseData {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long seq;
+
+    @Column(nullable = false)
+    private String deviceId;
+
+    private Double temVal;
+
+    private Double humVal;
+
+    private Double coVal;
+
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime regDate;
+
+    private HouseData(String deviceId, Double temVal, Double humVal, Double coVal) {
+        this.deviceId = deviceId;
+        this.temVal = temVal;
+        this.humVal = humVal;
+        this.coVal = coVal;
+    }
+
+    public static HouseData of(String deviceId, Double temVal, Double humVal, Double coVal) {
+        return new HouseData(deviceId, temVal, humVal, coVal);
+    }
+
+    public void update(String deviceId, Double temVal, Double humVal, Double coVal) {
+        if (deviceId != null) this.deviceId = deviceId;
+        if (temVal != null) this.temVal = temVal;
+        if (humVal != null) this.humVal = humVal;
+        if (coVal != null) this.coVal = coVal;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof HouseData that)) return false;
+        return this.seq != null && Objects.equals(this.seq, that.seq);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(seq);
+    }
+}

--- a/src/main/java/com/capstone/pethouse/domain/sensor/entity/NeckData.java
+++ b/src/main/java/com/capstone/pethouse/domain/sensor/entity/NeckData.java
@@ -1,0 +1,69 @@
+package com.capstone.pethouse.domain.sensor.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+import java.util.Objects;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+@Table(name = "neck_data", indexes = {
+        @Index(name = "idx_neck_data_device_id", columnList = "deviceId"),
+        @Index(name = "idx_neck_data_reg_date", columnList = "regDate")
+})
+@Entity
+public class NeckData {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long seq;
+
+    @Column(nullable = false)
+    private String deviceId;
+
+    private Double temVal;
+
+    private Double heartVal;
+
+    private Double coVal;
+
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime regDate;
+
+    private NeckData(String deviceId, Double temVal, Double heartVal, Double coVal) {
+        this.deviceId = deviceId;
+        this.temVal = temVal;
+        this.heartVal = heartVal;
+        this.coVal = coVal;
+    }
+
+    public static NeckData of(String deviceId, Double temVal, Double heartVal, Double coVal) {
+        return new NeckData(deviceId, temVal, heartVal, coVal);
+    }
+
+    public void update(String deviceId, Double temVal, Double heartVal, Double coVal) {
+        if (deviceId != null) this.deviceId = deviceId;
+        if (temVal != null) this.temVal = temVal;
+        if (heartVal != null) this.heartVal = heartVal;
+        if (coVal != null) this.coVal = coVal;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof NeckData that)) return false;
+        return this.seq != null && Objects.equals(this.seq, that.seq);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(seq);
+    }
+}

--- a/src/main/java/com/capstone/pethouse/domain/sensor/influx/InfluxWriter.java
+++ b/src/main/java/com/capstone/pethouse/domain/sensor/influx/InfluxWriter.java
@@ -1,0 +1,63 @@
+package com.capstone.pethouse.domain.sensor.influx;
+
+import com.influxdb.client.InfluxDBClient;
+import com.influxdb.client.WriteApiBlocking;
+import com.influxdb.client.domain.WritePrecision;
+import com.influxdb.client.write.Point;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.time.Instant;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class InfluxWriter {
+
+    public static final String MEASUREMENT_HOUSE = "house_sensor";
+    public static final String MEASUREMENT_NECK = "neck_sensor";
+
+    private final InfluxDBClient influxDBClient;
+
+    @Value("${influxdb.bucket}")
+    private String bucket;
+
+    @Value("${influxdb.org}")
+    private String influxOrg;
+
+    public void writeHouse(String deviceId, Double temVal, Double humVal, Double coVal) {
+        Point point = Point.measurement(MEASUREMENT_HOUSE)
+                .addTag("deviceId", deviceId)
+                .time(Instant.now(), WritePrecision.MS);
+
+        if (temVal != null) point.addField("temVal", temVal);
+        if (humVal != null) point.addField("humVal", humVal);
+        if (coVal != null) point.addField("coVal", coVal);
+
+        try {
+            WriteApiBlocking writeApi = influxDBClient.getWriteApiBlocking();
+            writeApi.writePoint(bucket, influxOrg, point);
+        } catch (Exception e) {
+            log.warn("InfluxDB write failed (house) for {}: {}", deviceId, e.getMessage());
+        }
+    }
+
+    public void writeNeck(String deviceId, Double temVal, Double heartVal, Double coVal) {
+        Point point = Point.measurement(MEASUREMENT_NECK)
+                .addTag("deviceId", deviceId)
+                .time(Instant.now(), WritePrecision.MS);
+
+        if (temVal != null) point.addField("temVal", temVal);
+        if (heartVal != null) point.addField("heartVal", heartVal);
+        if (coVal != null) point.addField("coVal", coVal);
+
+        try {
+            WriteApiBlocking writeApi = influxDBClient.getWriteApiBlocking();
+            writeApi.writePoint(bucket, influxOrg, point);
+        } catch (Exception e) {
+            log.warn("InfluxDB write failed (neck) for {}: {}", deviceId, e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/capstone/pethouse/domain/sensor/repository/HouseDataRepository.java
+++ b/src/main/java/com/capstone/pethouse/domain/sensor/repository/HouseDataRepository.java
@@ -1,0 +1,18 @@
+package com.capstone.pethouse.domain.sensor.repository;
+
+import com.capstone.pethouse.domain.sensor.entity.HouseData;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface HouseDataRepository extends JpaRepository<HouseData, Long> {
+
+    @Query("SELECT h FROM HouseData h WHERE " +
+            "(:searchQuery IS NULL OR :searchQuery = '' OR h.deviceId LIKE %:searchQuery%) " +
+            "ORDER BY h.regDate DESC")
+    Page<HouseData> findAllWithSearch(@Param("searchQuery") String searchQuery, Pageable pageable);
+}

--- a/src/main/java/com/capstone/pethouse/domain/sensor/repository/NeckDataRepository.java
+++ b/src/main/java/com/capstone/pethouse/domain/sensor/repository/NeckDataRepository.java
@@ -1,0 +1,18 @@
+package com.capstone.pethouse.domain.sensor.repository;
+
+import com.capstone.pethouse.domain.sensor.entity.NeckData;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface NeckDataRepository extends JpaRepository<NeckData, Long> {
+
+    @Query("SELECT n FROM NeckData n WHERE " +
+            "(:searchQuery IS NULL OR :searchQuery = '' OR n.deviceId LIKE %:searchQuery%) " +
+            "ORDER BY n.regDate DESC")
+    Page<NeckData> findAllWithSearch(@Param("searchQuery") String searchQuery, Pageable pageable);
+}

--- a/src/main/java/com/capstone/pethouse/domain/sensor/service/ChartService.java
+++ b/src/main/java/com/capstone/pethouse/domain/sensor/service/ChartService.java
@@ -1,0 +1,54 @@
+package com.capstone.pethouse.domain.sensor.service;
+
+import com.capstone.pethouse.domain.device.entity.Device;
+import com.capstone.pethouse.domain.device.repository.DeviceRepository;
+import com.capstone.pethouse.domain.sensor.dto.DataVo;
+import com.capstone.pethouse.domain.sensor.repository.HouseDataRepository;
+import com.capstone.pethouse.domain.sensor.repository.NeckDataRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collections;
+import java.util.List;
+
+@RequiredArgsConstructor
+@Service
+public class ChartService {
+
+    private static final int CHART_LIMIT = 1000;
+
+    private final DeviceRepository deviceRepository;
+    private final HouseDataRepository houseDataRepository;
+    private final NeckDataRepository neckDataRepository;
+
+    @Transactional(readOnly = true)
+    public List<DataVo> getChartData(String serialNum) {
+        if (serialNum == null || serialNum.isBlank()) {
+            return Collections.emptyList();
+        }
+
+        Device device = deviceRepository.findBySerialNum(serialNum).orElse(null);
+        if (device == null) {
+            return Collections.emptyList();
+        }
+
+        String deviceId = device.getDeviceId();
+        String type = device.getDeviceType();
+
+        PageRequest pageRequest = PageRequest.of(0, CHART_LIMIT);
+
+        if ("HOUSE".equalsIgnoreCase(type)) {
+            return houseDataRepository.findAllWithSearch(deviceId, pageRequest)
+                    .map(DataVo::fromHouse)
+                    .getContent();
+        } else if ("COLLAR".equalsIgnoreCase(type) || "NECK".equalsIgnoreCase(type)) {
+            return neckDataRepository.findAllWithSearch(deviceId, pageRequest)
+                    .map(DataVo::fromNeck)
+                    .getContent();
+        }
+
+        return Collections.emptyList();
+    }
+}

--- a/src/main/java/com/capstone/pethouse/domain/sensor/service/HouseDataService.java
+++ b/src/main/java/com/capstone/pethouse/domain/sensor/service/HouseDataService.java
@@ -1,0 +1,75 @@
+package com.capstone.pethouse.domain.sensor.service;
+
+import com.capstone.pethouse.domain.sensor.dto.DataVo;
+import com.capstone.pethouse.domain.sensor.dto.HouseDataRequest;
+import com.capstone.pethouse.domain.sensor.entity.HouseData;
+import com.capstone.pethouse.domain.sensor.influx.InfluxWriter;
+import com.capstone.pethouse.domain.sensor.repository.HouseDataRepository;
+import com.capstone.pethouse.domain.sensor.websocket.SensorPushService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+public class HouseDataService {
+
+    private final HouseDataRepository houseDataRepository;
+    private final InfluxWriter influxWriter;
+    private final SensorPushService sensorPushService;
+
+    @Transactional(readOnly = true)
+    public Page<DataVo> getList(int pageNum, int pageSize, String searchQuery) {
+        PageRequest pageRequest = PageRequest.of(Math.max(pageNum - 1, 0), pageSize);
+        return houseDataRepository.findAllWithSearch(searchQuery, pageRequest).map(DataVo::fromHouse);
+    }
+
+    @Transactional(readOnly = true)
+    public DataVo get(Long seq) {
+        HouseData data = houseDataRepository.findById(seq)
+                .orElseThrow(() -> new IllegalArgumentException("하우스 데이터를 찾을 수 없습니다."));
+        return DataVo.fromHouse(data);
+    }
+
+    /**
+     * HTTP/MQTT 양쪽에서 호출. RDB 저장 + InfluxDB write + WebSocket push.
+     */
+    @Transactional
+    public DataVo create(HouseDataRequest request) {
+        if (request.deviceId() == null || request.deviceId().isBlank()) {
+            throw new IllegalArgumentException("device_id는 필수입니다.");
+        }
+
+        HouseData saved = houseDataRepository.save(
+                HouseData.of(request.deviceId(), request.temVal(), request.humVal(), request.coVal())
+        );
+
+        DataVo vo = DataVo.fromHouse(saved);
+
+        // InfluxDB 시계열 저장
+        influxWriter.writeHouse(request.deviceId(), request.temVal(), request.humVal(), request.coVal());
+
+        // WebSocket 실시간 푸시
+        sensorPushService.pushHouse(vo);
+
+        return vo;
+    }
+
+    @Transactional
+    public DataVo update(Long seq, HouseDataRequest request) {
+        HouseData data = houseDataRepository.findById(seq)
+                .orElseThrow(() -> new IllegalArgumentException("하우스 데이터를 찾을 수 없습니다."));
+        data.update(request.deviceId(), request.temVal(), request.humVal(), request.coVal());
+        return DataVo.fromHouse(data);
+    }
+
+    @Transactional
+    public void delete(Long seq) {
+        if (!houseDataRepository.existsById(seq)) {
+            throw new IllegalArgumentException("하우스 데이터를 찾을 수 없습니다.");
+        }
+        houseDataRepository.deleteById(seq);
+    }
+}

--- a/src/main/java/com/capstone/pethouse/domain/sensor/service/NeckDataService.java
+++ b/src/main/java/com/capstone/pethouse/domain/sensor/service/NeckDataService.java
@@ -1,0 +1,69 @@
+package com.capstone.pethouse.domain.sensor.service;
+
+import com.capstone.pethouse.domain.sensor.dto.DataVo;
+import com.capstone.pethouse.domain.sensor.dto.NeckDataRequest;
+import com.capstone.pethouse.domain.sensor.entity.NeckData;
+import com.capstone.pethouse.domain.sensor.influx.InfluxWriter;
+import com.capstone.pethouse.domain.sensor.repository.NeckDataRepository;
+import com.capstone.pethouse.domain.sensor.websocket.SensorPushService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+public class NeckDataService {
+
+    private final NeckDataRepository neckDataRepository;
+    private final InfluxWriter influxWriter;
+    private final SensorPushService sensorPushService;
+
+    @Transactional(readOnly = true)
+    public Page<DataVo> getList(int pageNum, int pageSize, String searchQuery) {
+        PageRequest pageRequest = PageRequest.of(Math.max(pageNum - 1, 0), pageSize);
+        return neckDataRepository.findAllWithSearch(searchQuery, pageRequest).map(DataVo::fromNeck);
+    }
+
+    @Transactional(readOnly = true)
+    public DataVo get(Long seq) {
+        NeckData data = neckDataRepository.findById(seq)
+                .orElseThrow(() -> new IllegalArgumentException("목걸이 데이터를 찾을 수 없습니다."));
+        return DataVo.fromNeck(data);
+    }
+
+    @Transactional
+    public DataVo create(NeckDataRequest request) {
+        if (request.deviceId() == null || request.deviceId().isBlank()) {
+            throw new IllegalArgumentException("device_id는 필수입니다.");
+        }
+
+        NeckData saved = neckDataRepository.save(
+                NeckData.of(request.deviceId(), request.temVal(), request.heartVal(), request.coVal())
+        );
+
+        DataVo vo = DataVo.fromNeck(saved);
+
+        influxWriter.writeNeck(request.deviceId(), request.temVal(), request.heartVal(), request.coVal());
+        sensorPushService.pushNeck(vo);
+
+        return vo;
+    }
+
+    @Transactional
+    public DataVo update(Long seq, NeckDataRequest request) {
+        NeckData data = neckDataRepository.findById(seq)
+                .orElseThrow(() -> new IllegalArgumentException("목걸이 데이터를 찾을 수 없습니다."));
+        data.update(request.deviceId(), request.temVal(), request.heartVal(), request.coVal());
+        return DataVo.fromNeck(data);
+    }
+
+    @Transactional
+    public void delete(Long seq) {
+        if (!neckDataRepository.existsById(seq)) {
+            throw new IllegalArgumentException("목걸이 데이터를 찾을 수 없습니다.");
+        }
+        neckDataRepository.deleteById(seq);
+    }
+}

--- a/src/main/java/com/capstone/pethouse/domain/sensor/websocket/SensorPushService.java
+++ b/src/main/java/com/capstone/pethouse/domain/sensor/websocket/SensorPushService.java
@@ -1,0 +1,34 @@
+package com.capstone.pethouse.domain.sensor.websocket;
+
+import com.capstone.pethouse.domain.sensor.dto.DataVo;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class SensorPushService {
+
+    private static final String HOUSE_TOPIC_PREFIX = "/topic/sensor/house/";
+    private static final String NECK_TOPIC_PREFIX = "/topic/sensor/neck/";
+
+    private final SimpMessagingTemplate messagingTemplate;
+
+    public void pushHouse(DataVo data) {
+        try {
+            messagingTemplate.convertAndSend(HOUSE_TOPIC_PREFIX + data.deviceId(), data);
+        } catch (Exception e) {
+            log.warn("WebSocket push failed (house) for {}: {}", data.deviceId(), e.getMessage());
+        }
+    }
+
+    public void pushNeck(DataVo data) {
+        try {
+            messagingTemplate.convertAndSend(NECK_TOPIC_PREFIX + data.deviceId(), data);
+        } catch (Exception e) {
+            log.warn("WebSocket push failed (neck) for {}: {}", data.deviceId(), e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/capstone/pethouse/global/config/SecurityConfig.java
+++ b/src/main/java/com/capstone/pethouse/global/config/SecurityConfig.java
@@ -43,6 +43,13 @@ public class SecurityConfig {
                         .requestMatchers("/member/find-id", "/member/verify-user", "/member/reset-password").permitAll()
                         .requestMatchers("/device/checkMember", "/device/checkSerial").permitAll()
                         .requestMatchers("/device/deviceTypeCodes").permitAll()
+                        // Sensor 데이터 등록 (IoT 기기/앱) — 인증 없이 허용
+                        .requestMatchers(HttpMethod.POST, "/data/house", "/data/neck").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/data/**").permitAll()
+                        // 파일 업로드/스트리밍 (IoT 기기) — 인증 없이 허용
+                        .requestMatchers("/file/**").permitAll()
+                        // WebSocket
+                        .requestMatchers("/ws/**").permitAll()
                         .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                         .anyRequest().authenticated()
                 )

--- a/src/main/java/com/capstone/pethouse/infra/mqtt/handler/SensorDataHandler.java
+++ b/src/main/java/com/capstone/pethouse/infra/mqtt/handler/SensorDataHandler.java
@@ -1,20 +1,87 @@
 package com.capstone.pethouse.infra.mqtt.handler;
 
+import com.capstone.pethouse.domain.device.entity.Device;
+import com.capstone.pethouse.domain.device.repository.DeviceRepository;
+import com.capstone.pethouse.domain.sensor.dto.HouseDataRequest;
+import com.capstone.pethouse.domain.sensor.dto.NeckDataRequest;
+import com.capstone.pethouse.domain.sensor.service.HouseDataService;
+import com.capstone.pethouse.domain.sensor.service.NeckDataService;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
 @Slf4j
+@RequiredArgsConstructor
 @Component
 public class SensorDataHandler implements MqttMessageHandler {
+
+    private final ObjectMapper objectMapper;
+    private final HouseDataService houseDataService;
+    private final NeckDataService neckDataService;
+    private final DeviceRepository deviceRepository;
 
     @Override
     public boolean supports(String category) {
         return "sensor/data".equals(category);
     }
 
+    /**
+     * MQTT payload 예시:
+     * {"deviceId":"DEV001","temVal":25.3,"humVal":60.2,"coVal":412.5}
+     * {"deviceId":"DEV002","temVal":18.0,"heartVal":64.0,"coVal":404.0}
+     *
+     * deviceType 별로 분기:
+     * - HOUSE → HouseDataService.create()
+     * - COLLAR/NECK → NeckDataService.create()
+     */
     @Override
     public void handle(Long houseId, String category, String payload) {
-        log.info("Sensor data received — houseId={}, payload={}", houseId, payload);
-        // TASK-4에서 InfluxDB 저장 + WebSocket 푸시 구현 예정
+        log.debug("Sensor data received — houseId={}, payload={}", houseId, payload);
+
+        try {
+            JsonNode node = objectMapper.readTree(payload);
+            String deviceId = node.path("deviceId").asText(null);
+            if (deviceId == null) {
+                deviceId = node.path("device_id").asText(null);
+            }
+            if (deviceId == null) {
+                log.warn("Sensor data missing deviceId — houseId={}, payload={}", houseId, payload);
+                return;
+            }
+
+            Double temVal = readDouble(node, "temVal", "tem_val");
+            Double coVal = readDouble(node, "coVal", "co_val");
+
+            Device device = deviceRepository.findByDeviceId(deviceId).orElse(null);
+            String type = device != null ? device.getDeviceType() : null;
+
+            // heartVal이 있으면 NECK, 없으면 HOUSE로 추론 (type이 null인 경우)
+            Double heartVal = readDouble(node, "heartVal", "heart_val");
+            Double humVal = readDouble(node, "humVal", "hum_val");
+
+            boolean isNeck = "COLLAR".equalsIgnoreCase(type) || "NECK".equalsIgnoreCase(type)
+                    || (type == null && heartVal != null);
+
+            if (isNeck) {
+                neckDataService.create(new NeckDataRequest(deviceId, temVal, heartVal, coVal));
+            } else {
+                houseDataService.create(new HouseDataRequest(deviceId, temVal, humVal, coVal));
+            }
+        } catch (Exception e) {
+            log.error("Failed to process sensor data — houseId={}, payload={}, error={}",
+                    houseId, payload, e.getMessage(), e);
+        }
+    }
+
+    private Double readDouble(JsonNode node, String... keys) {
+        for (String key : keys) {
+            JsonNode v = node.get(key);
+            if (v != null && !v.isNull() && v.isNumber()) {
+                return v.asDouble();
+            }
+        }
+        return null;
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -46,6 +46,15 @@ mqtt:
 # InfluxDB
 influxdb:
   url: ${INFLUXDB_URL:http://localhost:8086}
-  token: ${INFLUXDB_TOKEN}
-  org: ${INFLUXDB_ORG:your-org-name}
-  bucket: ${INFLUXDB_BUCKET:your-bucket-name}
+  token: ${INFLUXDB_TOKEN:dev-token}
+  org: ${INFLUXDB_ORG:pethouse}
+  bucket: ${INFLUXDB_BUCKET:sensor_data}
+
+# File upload
+file:
+  upload-dir: ${FILE_UPLOAD_DIR:./uploads}
+
+# Multipart 업로드 사이즈 제한
+spring.servlet.multipart:
+  max-file-size: 50MB
+  max-request-size: 50MB

--- a/src/test/java/com/capstone/pethouse/domain/file/service/FileServiceTest.java
+++ b/src/test/java/com/capstone/pethouse/domain/file/service/FileServiceTest.java
@@ -1,0 +1,114 @@
+package com.capstone.pethouse.domain.file.service;
+
+import com.capstone.pethouse.domain.file.entity.FileInfo;
+import com.capstone.pethouse.domain.file.repository.FileRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class FileServiceTest {
+
+    @InjectMocks
+    private FileService fileService;
+
+    @Mock
+    private FileRepository fileRepository;
+
+    @TempDir
+    Path tempDir;
+
+    @BeforeEach
+    void setup() {
+        ReflectionTestUtils.setField(fileService, "uploadDir", tempDir.toString());
+    }
+
+    private FileInfo createFile() {
+        FileInfo f = FileInfo.of("DEV001", "test.mp3", tempDir.resolve("test.mp3").toString(), "audio/mpeg", 100L);
+        ReflectionTestUtils.setField(f, "seq", 1L);
+        ReflectionTestUtils.setField(f, "regDate", LocalDateTime.now());
+        return f;
+    }
+
+    @Test
+    @DisplayName("파일 업로드 성공 - 디스크 저장 + DB 등록")
+    void uploadSuccess() throws IOException {
+        MultipartFile file = new MockMultipartFile("file", "test.mp3", "audio/mpeg", "audio-content".getBytes());
+        FileInfo saved = createFile();
+
+        given(fileRepository.save(any(FileInfo.class))).willReturn(saved);
+
+        FileInfo result = fileService.upload("DEV001", "test.mp3", file);
+
+        assertThat(result.getDeviceId()).isEqualTo("DEV001");
+        verify(fileRepository).save(any(FileInfo.class));
+    }
+
+    @Test
+    @DisplayName("업로드 실패 - deviceId 누락")
+    void uploadFailNoDeviceId() {
+        MultipartFile file = new MockMultipartFile("file", "test.mp3", "audio/mpeg", "x".getBytes());
+
+        assertThatThrownBy(() -> fileService.upload(null, "test.mp3", file))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("업로드 실패 - 빈 파일")
+    void uploadFailEmptyFile() {
+        MultipartFile file = new MockMultipartFile("file", "test.mp3", "audio/mpeg", new byte[0]);
+
+        assertThatThrownBy(() -> fileService.upload("DEV001", "test.mp3", file))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("단일 조회 - deviceId 있을 때 findBySeqAndDeviceId 사용")
+    void getWithDeviceId() {
+        FileInfo f = createFile();
+        given(fileRepository.findBySeqAndDeviceId(1L, "DEV001")).willReturn(Optional.of(f));
+
+        var result = fileService.get(1L, "DEV001");
+
+        assertThat(result.deviceId()).isEqualTo("DEV001");
+    }
+
+    @Test
+    @DisplayName("단일 조회 - deviceId 없으면 findById")
+    void getWithoutDeviceId() {
+        FileInfo f = createFile();
+        given(fileRepository.findById(1L)).willReturn(Optional.of(f));
+
+        var result = fileService.get(1L, null);
+
+        assertThat(result.seq()).isEqualTo(1L);
+    }
+
+    @Test
+    @DisplayName("조회 실패")
+    void getNotFound() {
+        given(fileRepository.findById(999L)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> fileService.get(999L, null))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/src/test/java/com/capstone/pethouse/domain/sensor/service/ChartServiceTest.java
+++ b/src/test/java/com/capstone/pethouse/domain/sensor/service/ChartServiceTest.java
@@ -1,0 +1,101 @@
+package com.capstone.pethouse.domain.sensor.service;
+
+import com.capstone.pethouse.domain.device.entity.Device;
+import com.capstone.pethouse.domain.device.repository.DeviceRepository;
+import com.capstone.pethouse.domain.sensor.dto.DataVo;
+import com.capstone.pethouse.domain.sensor.entity.HouseData;
+import com.capstone.pethouse.domain.sensor.entity.NeckData;
+import com.capstone.pethouse.domain.sensor.repository.HouseDataRepository;
+import com.capstone.pethouse.domain.sensor.repository.NeckDataRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class ChartServiceTest {
+
+    @InjectMocks
+    private ChartService chartService;
+
+    @Mock
+    private DeviceRepository deviceRepository;
+
+    @Mock
+    private HouseDataRepository houseDataRepository;
+
+    @Mock
+    private NeckDataRepository neckDataRepository;
+
+    @Test
+    @DisplayName("HOUSE 타입 - 하우스 데이터 반환")
+    void chartForHouseDevice() {
+        Device device = Device.of("DEV001", "user01", "SN-001", "HOUSE");
+        ReflectionTestUtils.setField(device, "seq", 1L);
+
+        HouseData h = HouseData.of("DEV001", 25.0, 60.0, 400.0);
+        ReflectionTestUtils.setField(h, "seq", 1L);
+        ReflectionTestUtils.setField(h, "regDate", LocalDateTime.now());
+
+        Page<HouseData> page = new PageImpl<>(List.of(h));
+
+        given(deviceRepository.findBySerialNum("SN-001")).willReturn(Optional.of(device));
+        given(houseDataRepository.findAllWithSearch(eq("DEV001"), any(Pageable.class))).willReturn(page);
+
+        List<DataVo> result = chartService.getChartData("SN-001");
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).deviceId()).isEqualTo("DEV001");
+        assertThat(result.get(0).humVal()).isEqualTo(60.0);
+    }
+
+    @Test
+    @DisplayName("COLLAR 타입 - 목걸이 데이터 반환")
+    void chartForCollarDevice() {
+        Device device = Device.of("DEV002", "user01", "SN-002", "COLLAR");
+
+        NeckData n = NeckData.of("DEV002", 18.0, 64.0, 404.0);
+        ReflectionTestUtils.setField(n, "seq", 1L);
+        ReflectionTestUtils.setField(n, "regDate", LocalDateTime.now());
+
+        Page<NeckData> page = new PageImpl<>(List.of(n));
+
+        given(deviceRepository.findBySerialNum("SN-002")).willReturn(Optional.of(device));
+        given(neckDataRepository.findAllWithSearch(eq("DEV002"), any(Pageable.class))).willReturn(page);
+
+        List<DataVo> result = chartService.getChartData("SN-002");
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).heartVal()).isEqualTo(64.0);
+    }
+
+    @Test
+    @DisplayName("시리얼 없으면 빈 리스트")
+    void chartNoSerial() {
+        given(deviceRepository.findBySerialNum("SN-XXX")).willReturn(Optional.empty());
+
+        assertThat(chartService.getChartData("SN-XXX")).isEmpty();
+    }
+
+    @Test
+    @DisplayName("serialNum이 null/blank면 빈 리스트")
+    void chartNullSerial() {
+        assertThat(chartService.getChartData(null)).isEmpty();
+        assertThat(chartService.getChartData("")).isEmpty();
+    }
+}

--- a/src/test/java/com/capstone/pethouse/domain/sensor/service/HouseDataServiceTest.java
+++ b/src/test/java/com/capstone/pethouse/domain/sensor/service/HouseDataServiceTest.java
@@ -1,0 +1,127 @@
+package com.capstone.pethouse.domain.sensor.service;
+
+import com.capstone.pethouse.domain.sensor.dto.DataVo;
+import com.capstone.pethouse.domain.sensor.dto.HouseDataRequest;
+import com.capstone.pethouse.domain.sensor.entity.HouseData;
+import com.capstone.pethouse.domain.sensor.influx.InfluxWriter;
+import com.capstone.pethouse.domain.sensor.repository.HouseDataRepository;
+import com.capstone.pethouse.domain.sensor.websocket.SensorPushService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class HouseDataServiceTest {
+
+    @InjectMocks
+    private HouseDataService houseDataService;
+
+    @Mock
+    private HouseDataRepository houseDataRepository;
+
+    @Mock
+    private InfluxWriter influxWriter;
+
+    @Mock
+    private SensorPushService sensorPushService;
+
+    private HouseData createHouseData() {
+        HouseData data = HouseData.of("DEV001", 25.3, 60.0, 410.0);
+        ReflectionTestUtils.setField(data, "seq", 1L);
+        ReflectionTestUtils.setField(data, "regDate", LocalDateTime.now());
+        return data;
+    }
+
+    @Test
+    @DisplayName("하우스 데이터 등록 - RDB 저장 + Influx write + WebSocket push")
+    void createSuccess() {
+        HouseDataRequest request = new HouseDataRequest("DEV001", 25.3, 60.0, 410.0);
+        HouseData saved = createHouseData();
+
+        given(houseDataRepository.save(any(HouseData.class))).willReturn(saved);
+
+        DataVo response = houseDataService.create(request);
+
+        assertThat(response.deviceId()).isEqualTo("DEV001");
+        assertThat(response.temVal()).isEqualTo(25.3);
+        verify(influxWriter).writeHouse("DEV001", 25.3, 60.0, 410.0);
+        verify(sensorPushService).pushHouse(any(DataVo.class));
+    }
+
+    @Test
+    @DisplayName("등록 실패 - device_id 누락")
+    void createFailNoDeviceId() {
+        HouseDataRequest request = new HouseDataRequest(null, 25.3, 60.0, 410.0);
+
+        assertThatThrownBy(() -> houseDataService.create(request))
+                .isInstanceOf(IllegalArgumentException.class);
+
+        verifyNoInteractions(influxWriter, sensorPushService);
+    }
+
+    @Test
+    @DisplayName("단일 조회 성공")
+    void getSuccess() {
+        HouseData data = createHouseData();
+        given(houseDataRepository.findById(1L)).willReturn(Optional.of(data));
+
+        DataVo response = houseDataService.get(1L);
+
+        assertThat(response.seq()).isEqualTo(1L);
+    }
+
+    @Test
+    @DisplayName("단일 조회 실패")
+    void getNotFound() {
+        given(houseDataRepository.findById(999L)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> houseDataService.get(999L))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("수정 성공")
+    void updateSuccess() {
+        HouseData data = createHouseData();
+        HouseDataRequest request = new HouseDataRequest("DEV001", 30.0, 65.0, 500.0);
+
+        given(houseDataRepository.findById(1L)).willReturn(Optional.of(data));
+
+        houseDataService.update(1L, request);
+
+        assertThat(data.getTemVal()).isEqualTo(30.0);
+        assertThat(data.getCoVal()).isEqualTo(500.0);
+    }
+
+    @Test
+    @DisplayName("삭제 성공")
+    void deleteSuccess() {
+        given(houseDataRepository.existsById(1L)).willReturn(true);
+
+        houseDataService.delete(1L);
+
+        verify(houseDataRepository).deleteById(1L);
+    }
+
+    @Test
+    @DisplayName("삭제 실패 - 존재하지 않음")
+    void deleteNotFound() {
+        given(houseDataRepository.existsById(999L)).willReturn(false);
+
+        assertThatThrownBy(() -> houseDataService.delete(999L))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/src/test/java/com/capstone/pethouse/domain/sensor/service/NeckDataServiceTest.java
+++ b/src/test/java/com/capstone/pethouse/domain/sensor/service/NeckDataServiceTest.java
@@ -1,0 +1,96 @@
+package com.capstone.pethouse.domain.sensor.service;
+
+import com.capstone.pethouse.domain.sensor.dto.DataVo;
+import com.capstone.pethouse.domain.sensor.dto.NeckDataRequest;
+import com.capstone.pethouse.domain.sensor.entity.NeckData;
+import com.capstone.pethouse.domain.sensor.influx.InfluxWriter;
+import com.capstone.pethouse.domain.sensor.repository.NeckDataRepository;
+import com.capstone.pethouse.domain.sensor.websocket.SensorPushService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class NeckDataServiceTest {
+
+    @InjectMocks
+    private NeckDataService neckDataService;
+
+    @Mock
+    private NeckDataRepository neckDataRepository;
+
+    @Mock
+    private InfluxWriter influxWriter;
+
+    @Mock
+    private SensorPushService sensorPushService;
+
+    private NeckData createNeckData() {
+        NeckData data = NeckData.of("DEV002", 18.0, 64.0, 404.0);
+        ReflectionTestUtils.setField(data, "seq", 2L);
+        ReflectionTestUtils.setField(data, "regDate", LocalDateTime.now());
+        return data;
+    }
+
+    @Test
+    @DisplayName("목걸이 데이터 등록 - RDB + Influx + WebSocket")
+    void createSuccess() {
+        NeckDataRequest request = new NeckDataRequest("DEV002", 18.0, 64.0, 404.0);
+        NeckData saved = createNeckData();
+
+        given(neckDataRepository.save(any(NeckData.class))).willReturn(saved);
+
+        DataVo response = neckDataService.create(request);
+
+        assertThat(response.deviceId()).isEqualTo("DEV002");
+        assertThat(response.heartVal()).isEqualTo(64.0);
+        verify(influxWriter).writeNeck("DEV002", 18.0, 64.0, 404.0);
+        verify(sensorPushService).pushNeck(any(DataVo.class));
+    }
+
+    @Test
+    @DisplayName("단일 조회")
+    void getSuccess() {
+        NeckData data = createNeckData();
+        given(neckDataRepository.findById(2L)).willReturn(Optional.of(data));
+
+        DataVo response = neckDataService.get(2L);
+
+        assertThat(response.heartVal()).isEqualTo(64.0);
+    }
+
+    @Test
+    @DisplayName("수정 성공")
+    void updateSuccess() {
+        NeckData data = createNeckData();
+        NeckDataRequest request = new NeckDataRequest("DEV002", 20.0, 70.0, 410.0);
+
+        given(neckDataRepository.findById(2L)).willReturn(Optional.of(data));
+
+        neckDataService.update(2L, request);
+
+        assertThat(data.getHeartVal()).isEqualTo(70.0);
+    }
+
+    @Test
+    @DisplayName("삭제 실패")
+    void deleteFail() {
+        given(neckDataRepository.existsById(999L)).willReturn(false);
+
+        assertThatThrownBy(() -> neckDataService.delete(999L))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+}


### PR DESCRIPTION
## Summary
- House/Neck 센서 데이터 CRUD (총 10개)
- POST 시 RDB + InfluxDB(시계열) + WebSocket(STOMP) 실시간 푸시
- Chart API: 시리얼 기준 차트 데이터 조회 (deviceType 분기)
- 파일(오디오) CRUD + 스트리밍/다운로드 (총 7개)
- MQTT SensorDataHandler ↔ Service 연결

## 구현 항목 (18개 API)
### House (5)
- GET /api/data/house/list, /{seq}
- POST /api/data/house — 등록 + 알림(InfluxDB write + WS push)
- PUT /api/data/house/{seq}
- DELETE /api/data/house/{seq}

### Neck (5)
- GET /api/data/neck/list, /{seq}
- POST /api/data/neck — 등록 + 알림
- PUT /api/data/neck/{seq}
- DELETE /api/data/neck/{seq}

### Chart (1)
- GET /api/data/chart?serialNum=...

### File (7)
- GET /api/file/list, /{seq}
- POST /api/file (multipart) — 업로드 + 디스크 저장
- PUT /api/file (multipart) — 정보/파일 수정
- DELETE /api/file
- GET /api/file/audio/{seq} — inline 스트리밍
- GET /api/file/download/{seq} — attachment 다운로드

## Test plan
- [x] HouseDataServiceTest (7개)
- [x] NeckDataServiceTest (4개)
- [x] ChartServiceTest (4개)
- [x] FileServiceTest (6개)
- [x] 빌드 성공
- [ ] 통합 환경에서 MQTT 발행 → DB 저장 + WebSocket 푸시 확인
- [ ] InfluxDB 실제 인스턴스 연결하여 시계열 저장 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)