### PR TITLE
[#58] 디바이스 명세 v0.3 A 담당분 구현 (/api/data, /api/command/fetch)

### DIFF
--- a/src/main/java/com/capstone/pethouse/domain/iot/controller/IotCommandController.java
+++ b/src/main/java/com/capstone/pethouse/domain/iot/controller/IotCommandController.java
@@ -1,0 +1,30 @@
+package com.capstone.pethouse.domain.iot.controller;
+
+import com.capstone.pethouse.domain.iot.dto.CommandFetchRequest;
+import com.capstone.pethouse.domain.iot.dto.CommandFetchResponse;
+import com.capstone.pethouse.domain.iot.service.DeviceCommandService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+/**
+ * 디바이스 명세 v0.3 - POST /api/command/fetch
+ * IoT 디바이스가 자기 SN의 대기(W) 명령을 폴링.
+ */
+@RequiredArgsConstructor
+@RequestMapping("/command")
+@RestController
+public class IotCommandController {
+
+    private final DeviceCommandService deviceCommandService;
+
+    @PostMapping("/fetch")
+    public ResponseEntity<List<CommandFetchResponse>> fetch(@RequestBody CommandFetchRequest request) {
+        return ResponseEntity.ok(deviceCommandService.fetch(request.sn()));
+    }
+}

--- a/src/main/java/com/capstone/pethouse/domain/iot/controller/IotDataController.java
+++ b/src/main/java/com/capstone/pethouse/domain/iot/controller/IotDataController.java
@@ -1,0 +1,28 @@
+package com.capstone.pethouse.domain.iot.controller;
+
+import com.capstone.pethouse.domain.iot.dto.IotDataRequest;
+import com.capstone.pethouse.domain.iot.service.IotDataService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 디바이스 명세 v0.3 - POST /api/data
+ * IoT 디바이스가 환경 데이터(SN/T/H/CO)를 직접 등록.
+ */
+@RequiredArgsConstructor
+@RequestMapping("/data")
+@RestController
+public class IotDataController {
+
+    private final IotDataService iotDataService;
+
+    @PostMapping
+    public ResponseEntity<String> register(@RequestBody IotDataRequest request) {
+        iotDataService.registerEnvironmentData(request);
+        return ResponseEntity.ok("등록 및 알림 처리 완료");
+    }
+}

--- a/src/main/java/com/capstone/pethouse/domain/iot/dto/CommandFetchRequest.java
+++ b/src/main/java/com/capstone/pethouse/domain/iot/dto/CommandFetchRequest.java
@@ -1,0 +1,12 @@
+package com.capstone.pethouse.domain.iot.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * 디바이스 명세 v0.3 - POST /api/command/fetch
+ * 디바이스가 자기 SN의 대기 명령을 폴링.
+ */
+public record CommandFetchRequest(
+        @JsonProperty("SN") String sn
+) {
+}

--- a/src/main/java/com/capstone/pethouse/domain/iot/dto/CommandFetchResponse.java
+++ b/src/main/java/com/capstone/pethouse/domain/iot/dto/CommandFetchResponse.java
@@ -1,0 +1,16 @@
+package com.capstone.pethouse.domain.iot.dto;
+
+import com.capstone.pethouse.domain.iot.entity.DeviceCommand;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * 디바이스 명세 v0.3 - 응답: [{ "SEQ": Integer, "CT": String }]
+ */
+public record CommandFetchResponse(
+        @JsonProperty("SEQ") Long seq,
+        @JsonProperty("CT") String ct
+) {
+    public static CommandFetchResponse from(DeviceCommand c) {
+        return new CommandFetchResponse(c.getSeq(), c.getCt());
+    }
+}

--- a/src/main/java/com/capstone/pethouse/domain/iot/dto/IotDataRequest.java
+++ b/src/main/java/com/capstone/pethouse/domain/iot/dto/IotDataRequest.java
@@ -1,0 +1,16 @@
+package com.capstone.pethouse.domain.iot.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * 디바이스 명세 v0.3 - POST /api/data
+ * 디바이스가 직접 호출하는 환경 데이터 등록 API.
+ * 필드명이 짧음 (대역폭 절약).
+ */
+public record IotDataRequest(
+        @JsonProperty("SN") String sn,    // 시리얼 번호
+        @JsonProperty("T") Double t,      // 온도
+        @JsonProperty("H") Double h,      // 습도
+        @JsonProperty("CO") Double co     // CO 농도
+) {
+}

--- a/src/main/java/com/capstone/pethouse/domain/iot/entity/DeviceCommand.java
+++ b/src/main/java/com/capstone/pethouse/domain/iot/entity/DeviceCommand.java
@@ -1,0 +1,88 @@
+package com.capstone.pethouse.domain.iot.entity;
+
+import com.capstone.pethouse.domain.iot.enums.CommandStatus;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+import java.util.Objects;
+
+/**
+ * 서버 → 디바이스 명령 큐.
+ * 디바이스가 /api/command/fetch로 폴링하여 자기 SN의 W 상태 명령을 가져감.
+ */
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+@Table(name = "device_command", indexes = {
+        @Index(name = "idx_device_command_sn_status", columnList = "sn,status"),
+        @Index(name = "idx_device_command_status", columnList = "status")
+})
+@Entity
+public class DeviceCommand {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long seq;
+
+    @Column(nullable = false)
+    private String sn;
+
+    /**
+     * 명령 타입 (예: FEED, WATER, FAN_ON, FAN_OFF)
+     */
+    @Column(nullable = false)
+    private String ct;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 1)
+    private CommandStatus status;
+
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(nullable = false)
+    private LocalDateTime updatedAt;
+
+    private DeviceCommand(String sn, String ct, CommandStatus status) {
+        this.sn = sn;
+        this.ct = ct;
+        this.status = status;
+    }
+
+    /**
+     * 큐에 새 명령 추가 (W 상태로 시작). B 도메인에서 호출.
+     */
+    public static DeviceCommand enqueue(String sn, String ct) {
+        return new DeviceCommand(sn, ct, CommandStatus.W);
+    }
+
+    /** fetch 시 호출 — W → S 전환 */
+    public void markSent() {
+        this.status = CommandStatus.S;
+    }
+
+    /** result 시 호출 — S → E 전환 (FEN처럼 보존이 필요한 경우만) */
+    public void markExecuted() {
+        this.status = CommandStatus.E;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof DeviceCommand that)) return false;
+        return this.seq != null && Objects.equals(this.seq, that.seq);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(seq);
+    }
+}

--- a/src/main/java/com/capstone/pethouse/domain/iot/enums/CommandStatus.java
+++ b/src/main/java/com/capstone/pethouse/domain/iot/enums/CommandStatus.java
@@ -1,0 +1,11 @@
+package com.capstone.pethouse.domain.iot.enums;
+
+/**
+ * 디바이스 명령 큐 상태.
+ * - W: Waiting — 큐에 등록된 직후 (디바이스가 아직 받지 못함)
+ * - S: Sent — fetch 호출로 디바이스에 전달됨
+ * - E: Executed — 디바이스가 결과 보고 (FEN처럼 상태 보존이 필요한 경우)
+ */
+public enum CommandStatus {
+    W, S, E
+}

--- a/src/main/java/com/capstone/pethouse/domain/iot/repository/DeviceCommandRepository.java
+++ b/src/main/java/com/capstone/pethouse/domain/iot/repository/DeviceCommandRepository.java
@@ -2,7 +2,11 @@ package com.capstone.pethouse.domain.iot.repository;
 
 import com.capstone.pethouse.domain.iot.entity.DeviceCommand;
 import com.capstone.pethouse.domain.iot.enums.CommandStatus;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -14,4 +18,18 @@ public interface DeviceCommandRepository extends JpaRepository<DeviceCommand, Lo
      * SN의 대기(W) 중인 명령 조회 (오래된 순).
      */
     List<DeviceCommand> findBySnAndStatusOrderBySeqAsc(String sn, CommandStatus status);
+
+    /**
+     * fetch 전용 — 같은 SN 동시 폴링 시 중복 전달을 막기 위해 X-Lock 획득.
+     *
+     * 동작:
+     *   - 같은 SN의 W 행에 SELECT ... FOR UPDATE 락
+     *   - 두 번째 동시 호출은 첫 호출의 트랜잭션 종료까지 BLOCK
+     *   - 첫 호출이 W→S 전환 + 커밋하면, 두 번째는 빈 리스트 받음
+     *   - 다른 SN은 영향 없음 (행 단위 락)
+     */
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT c FROM DeviceCommand c WHERE c.sn = :sn AND c.status = :status ORDER BY c.seq ASC")
+    List<DeviceCommand> findForFetchWithLock(@Param("sn") String sn,
+                                              @Param("status") CommandStatus status);
 }

--- a/src/main/java/com/capstone/pethouse/domain/iot/repository/DeviceCommandRepository.java
+++ b/src/main/java/com/capstone/pethouse/domain/iot/repository/DeviceCommandRepository.java
@@ -1,0 +1,17 @@
+package com.capstone.pethouse.domain.iot.repository;
+
+import com.capstone.pethouse.domain.iot.entity.DeviceCommand;
+import com.capstone.pethouse.domain.iot.enums.CommandStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface DeviceCommandRepository extends JpaRepository<DeviceCommand, Long> {
+
+    /**
+     * SN의 대기(W) 중인 명령 조회 (오래된 순).
+     */
+    List<DeviceCommand> findBySnAndStatusOrderBySeqAsc(String sn, CommandStatus status);
+}

--- a/src/main/java/com/capstone/pethouse/domain/iot/service/DeviceCommandService.java
+++ b/src/main/java/com/capstone/pethouse/domain/iot/service/DeviceCommandService.java
@@ -1,0 +1,65 @@
+package com.capstone.pethouse.domain.iot.service;
+
+import com.capstone.pethouse.domain.iot.dto.CommandFetchResponse;
+import com.capstone.pethouse.domain.iot.entity.DeviceCommand;
+import com.capstone.pethouse.domain.iot.enums.CommandStatus;
+import com.capstone.pethouse.domain.iot.repository.DeviceCommandRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+/**
+ * 명령 큐 시스템.
+ *
+ * - enqueue: B 도메인이 사용 (예: Feeder가 "급식 명령 추가")
+ * - fetch: 디바이스가 폴링하여 자기 SN의 W 명령 가져감 → S로 전환
+ */
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class DeviceCommandService {
+
+    private final DeviceCommandRepository deviceCommandRepository;
+
+    /**
+     * B 도메인이 명령을 큐에 추가할 때 호출 (인프라 API).
+     * 예: FeederService.feedNow() → deviceCommandService.enqueue(sn, "FEED")
+     */
+    @Transactional
+    public DeviceCommand enqueue(String sn, String ct) {
+        if (sn == null || sn.isBlank()) {
+            throw new IllegalArgumentException("SN은 필수입니다.");
+        }
+        if (ct == null || ct.isBlank()) {
+            throw new IllegalArgumentException("CT(명령 타입)는 필수입니다.");
+        }
+        return deviceCommandRepository.save(DeviceCommand.enqueue(sn, ct));
+    }
+
+    /**
+     * 디바이스 명세 v0.3 - POST /api/command/fetch
+     *
+     * 해당 SN의 W 상태 명령을 모두 반환하고 status를 S로 전환.
+     * 같은 명령이 중복 fetch되지 않도록 보장.
+     */
+    @Transactional
+    public List<CommandFetchResponse> fetch(String sn) {
+        if (sn == null || sn.isBlank()) {
+            throw new IllegalArgumentException("SN은 필수입니다.");
+        }
+
+        List<DeviceCommand> waiting = deviceCommandRepository.findBySnAndStatusOrderBySeqAsc(sn, CommandStatus.W);
+
+        // W → S 전환 (같은 트랜잭션 내 dirty checking으로 update 됨)
+        waiting.forEach(DeviceCommand::markSent);
+
+        log.debug("Command fetch — SN={}, count={}", sn, waiting.size());
+
+        return waiting.stream()
+                .map(CommandFetchResponse::from)
+                .toList();
+    }
+}

--- a/src/main/java/com/capstone/pethouse/domain/iot/service/DeviceCommandService.java
+++ b/src/main/java/com/capstone/pethouse/domain/iot/service/DeviceCommandService.java
@@ -51,7 +51,8 @@ public class DeviceCommandService {
             throw new IllegalArgumentException("SN은 필수입니다.");
         }
 
-        List<DeviceCommand> waiting = deviceCommandRepository.findBySnAndStatusOrderBySeqAsc(sn, CommandStatus.W);
+        // PESSIMISTIC_WRITE 락으로 같은 SN 동시 폴링 race 차단
+        List<DeviceCommand> waiting = deviceCommandRepository.findForFetchWithLock(sn, CommandStatus.W);
 
         // W → S 전환 (같은 트랜잭션 내 dirty checking으로 update 됨)
         waiting.forEach(DeviceCommand::markSent);

--- a/src/main/java/com/capstone/pethouse/domain/iot/service/IotDataService.java
+++ b/src/main/java/com/capstone/pethouse/domain/iot/service/IotDataService.java
@@ -1,0 +1,53 @@
+package com.capstone.pethouse.domain.iot.service;
+
+import com.capstone.pethouse.domain.device.entity.Device;
+import com.capstone.pethouse.domain.device.repository.DeviceRepository;
+import com.capstone.pethouse.domain.iot.dto.IotDataRequest;
+import com.capstone.pethouse.domain.sensor.dto.HouseDataRequest;
+import com.capstone.pethouse.domain.sensor.service.HouseDataService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 디바이스 명세 v0.3 - POST /api/data
+ *
+ * 흐름:
+ *   1) SN(시리얼 번호)로 Device 매핑하여 deviceId 획득
+ *   2) HouseDataService.create()에 위임 → RDB 저장 + InfluxDB write + WebSocket push
+ *   3) 알림 처리(임계값 초과 시 등)는 추후 확장
+ *
+ * 사용자 시나리오: IoT 디바이스가 직접 호출.
+ */
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class IotDataService {
+
+    private final DeviceRepository deviceRepository;
+    private final HouseDataService houseDataService;
+
+    @Transactional
+    public void registerEnvironmentData(IotDataRequest request) {
+        if (request.sn() == null || request.sn().isBlank()) {
+            throw new IllegalArgumentException("SN은 필수입니다.");
+        }
+
+        Device device = deviceRepository.findBySerialNum(request.sn())
+                .orElseThrow(() -> new IllegalArgumentException("등록되지 않은 시리얼: " + request.sn()));
+
+        // 명세상 H(습도)는 House 디바이스 데이터에만 의미가 있음.
+        // /api/data는 환경(하우스) 데이터 전용이라 그대로 HouseData에 저장.
+        HouseDataRequest mapped = new HouseDataRequest(
+                device.getDeviceId(),
+                request.t(),
+                request.h(),
+                request.co()
+        );
+        houseDataService.create(mapped);
+
+        // TODO: 알림 임계값 초과 시 FCM 발송 — B 도메인 (Notifications) 구현 시 연동
+        log.debug("IoT data registered — SN={}, deviceId={}", request.sn(), device.getDeviceId());
+    }
+}

--- a/src/main/java/com/capstone/pethouse/global/config/SecurityConfig.java
+++ b/src/main/java/com/capstone/pethouse/global/config/SecurityConfig.java
@@ -46,6 +46,9 @@ public class SecurityConfig {
                         // Sensor 데이터 등록 (IoT 기기/앱) — 인증 없이 허용
                         .requestMatchers(HttpMethod.POST, "/data/house", "/data/neck").permitAll()
                         .requestMatchers(HttpMethod.GET, "/data/**").permitAll()
+                        // 디바이스 명세 v0.3 — IoT 디바이스 직접 호출
+                        .requestMatchers(HttpMethod.POST, "/data").permitAll()
+                        .requestMatchers(HttpMethod.POST, "/command/fetch").permitAll()
                         // 파일 업로드/스트리밍 (IoT 기기) — 인증 없이 허용
                         .requestMatchers("/file/**").permitAll()
                         // WebSocket

--- a/src/test/java/com/capstone/pethouse/domain/iot/service/DeviceCommandServiceTest.java
+++ b/src/test/java/com/capstone/pethouse/domain/iot/service/DeviceCommandServiceTest.java
@@ -1,0 +1,100 @@
+package com.capstone.pethouse.domain.iot.service;
+
+import com.capstone.pethouse.domain.iot.dto.CommandFetchResponse;
+import com.capstone.pethouse.domain.iot.entity.DeviceCommand;
+import com.capstone.pethouse.domain.iot.enums.CommandStatus;
+import com.capstone.pethouse.domain.iot.repository.DeviceCommandRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class DeviceCommandServiceTest {
+
+    @InjectMocks
+    private DeviceCommandService deviceCommandService;
+
+    @Mock
+    private DeviceCommandRepository deviceCommandRepository;
+
+    private DeviceCommand cmd(Long seq, String sn, String ct, CommandStatus status) {
+        DeviceCommand c = DeviceCommand.enqueue(sn, ct);
+        ReflectionTestUtils.setField(c, "seq", seq);
+        ReflectionTestUtils.setField(c, "status", status);
+        return c;
+    }
+
+    @Test
+    @DisplayName("enqueue - 명령을 W 상태로 큐에 추가")
+    void enqueueSuccess() {
+        DeviceCommand saved = cmd(1L, "SN-001", "FEED", CommandStatus.W);
+        given(deviceCommandRepository.save(any(DeviceCommand.class))).willReturn(saved);
+
+        DeviceCommand result = deviceCommandService.enqueue("SN-001", "FEED");
+
+        assertThat(result.getSn()).isEqualTo("SN-001");
+        assertThat(result.getCt()).isEqualTo("FEED");
+        assertThat(result.getStatus()).isEqualTo(CommandStatus.W);
+    }
+
+    @Test
+    @DisplayName("enqueue 실패 - SN/CT 누락")
+    void enqueueFail() {
+        assertThatThrownBy(() -> deviceCommandService.enqueue(null, "FEED"))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> deviceCommandService.enqueue("SN-001", null))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> deviceCommandService.enqueue("SN-001", "  "))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("fetch - W 명령 반환 + status W→S 전환")
+    void fetchSuccess() {
+        DeviceCommand c1 = cmd(1L, "SN-001", "FEED", CommandStatus.W);
+        DeviceCommand c2 = cmd(2L, "SN-001", "WATER", CommandStatus.W);
+
+        given(deviceCommandRepository.findBySnAndStatusOrderBySeqAsc("SN-001", CommandStatus.W))
+                .willReturn(List.of(c1, c2));
+
+        List<CommandFetchResponse> result = deviceCommandService.fetch("SN-001");
+
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).seq()).isEqualTo(1L);
+        assertThat(result.get(0).ct()).isEqualTo("FEED");
+        assertThat(result.get(1).ct()).isEqualTo("WATER");
+
+        // status 전환 확인
+        assertThat(c1.getStatus()).isEqualTo(CommandStatus.S);
+        assertThat(c2.getStatus()).isEqualTo(CommandStatus.S);
+    }
+
+    @Test
+    @DisplayName("fetch - W 명령 없으면 빈 리스트")
+    void fetchEmpty() {
+        given(deviceCommandRepository.findBySnAndStatusOrderBySeqAsc("SN-002", CommandStatus.W))
+                .willReturn(List.of());
+
+        assertThat(deviceCommandService.fetch("SN-002")).isEmpty();
+    }
+
+    @Test
+    @DisplayName("fetch 실패 - SN 누락")
+    void fetchFailNoSn() {
+        assertThatThrownBy(() -> deviceCommandService.fetch(null))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> deviceCommandService.fetch("  "))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/src/test/java/com/capstone/pethouse/domain/iot/service/DeviceCommandServiceTest.java
+++ b/src/test/java/com/capstone/pethouse/domain/iot/service/DeviceCommandServiceTest.java
@@ -65,7 +65,7 @@ class DeviceCommandServiceTest {
         DeviceCommand c1 = cmd(1L, "SN-001", "FEED", CommandStatus.W);
         DeviceCommand c2 = cmd(2L, "SN-001", "WATER", CommandStatus.W);
 
-        given(deviceCommandRepository.findBySnAndStatusOrderBySeqAsc("SN-001", CommandStatus.W))
+        given(deviceCommandRepository.findForFetchWithLock("SN-001", CommandStatus.W))
                 .willReturn(List.of(c1, c2));
 
         List<CommandFetchResponse> result = deviceCommandService.fetch("SN-001");
@@ -83,7 +83,7 @@ class DeviceCommandServiceTest {
     @Test
     @DisplayName("fetch - W 명령 없으면 빈 리스트")
     void fetchEmpty() {
-        given(deviceCommandRepository.findBySnAndStatusOrderBySeqAsc("SN-002", CommandStatus.W))
+        given(deviceCommandRepository.findForFetchWithLock("SN-002", CommandStatus.W))
                 .willReturn(List.of());
 
         assertThat(deviceCommandService.fetch("SN-002")).isEmpty();

--- a/src/test/java/com/capstone/pethouse/domain/iot/service/IotDataServiceTest.java
+++ b/src/test/java/com/capstone/pethouse/domain/iot/service/IotDataServiceTest.java
@@ -1,0 +1,87 @@
+package com.capstone.pethouse.domain.iot.service;
+
+import com.capstone.pethouse.domain.device.entity.Device;
+import com.capstone.pethouse.domain.device.repository.DeviceRepository;
+import com.capstone.pethouse.domain.iot.dto.IotDataRequest;
+import com.capstone.pethouse.domain.sensor.dto.HouseDataRequest;
+import com.capstone.pethouse.domain.sensor.service.HouseDataService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+@ExtendWith(MockitoExtension.class)
+class IotDataServiceTest {
+
+    @InjectMocks
+    private IotDataService iotDataService;
+
+    @Mock
+    private DeviceRepository deviceRepository;
+
+    @Mock
+    private HouseDataService houseDataService;
+
+    private Device createDevice() {
+        Device d = Device.of("DEV001", "user01", "SN-001", "HOUSE");
+        ReflectionTestUtils.setField(d, "seq", 1L);
+        return d;
+    }
+
+    @Test
+    @DisplayName("환경 데이터 등록 - SN→deviceId 매핑 후 HouseDataService 위임")
+    void registerSuccess() {
+        IotDataRequest req = new IotDataRequest("SN-001", 25.3, 60.0, 410.0);
+        Device device = createDevice();
+
+        given(deviceRepository.findBySerialNum("SN-001")).willReturn(Optional.of(device));
+
+        iotDataService.registerEnvironmentData(req);
+
+        ArgumentCaptor<HouseDataRequest> captor = ArgumentCaptor.forClass(HouseDataRequest.class);
+        verify(houseDataService).create(captor.capture());
+
+        HouseDataRequest mapped = captor.getValue();
+        assertThat(mapped.deviceId()).isEqualTo("DEV001");
+        assertThat(mapped.temVal()).isEqualTo(25.3);
+        assertThat(mapped.humVal()).isEqualTo(60.0);
+        assertThat(mapped.coVal()).isEqualTo(410.0);
+    }
+
+    @Test
+    @DisplayName("등록 실패 - SN 누락")
+    void registerFailNoSn() {
+        IotDataRequest req = new IotDataRequest(null, 25.0, 60.0, 400.0);
+
+        assertThatThrownBy(() -> iotDataService.registerEnvironmentData(req))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("SN");
+
+        verifyNoInteractions(houseDataService);
+    }
+
+    @Test
+    @DisplayName("등록 실패 - 미등록 시리얼")
+    void registerFailUnknownSerial() {
+        IotDataRequest req = new IotDataRequest("SN-XXX", 25.0, 60.0, 400.0);
+        given(deviceRepository.findBySerialNum("SN-XXX")).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> iotDataService.registerEnvironmentData(req))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("등록되지 않은 시리얼");
+
+        verifyNoInteractions(houseDataService);
+    }
+}


### PR DESCRIPTION
## Summary
디바이스 명세 v0.3 (5개 API 중) **개발자 A 담당 2개**만 구현.
- `POST /api/data` — IoT 디바이스 환경 데이터 등록 (SN/T/H/CO)
- `POST /api/command/fetch` — IoT 디바이스 명령 큐 폴링

나머지 3개(searchSerial, state, result+FCM)는 B 영역.

## 구현 항목

### 1) POST /api/data
- IoT 디바이스가 직접 호출 (인증 없음)
- SN(시리얼번호) → DeviceRepository에서 deviceId 매핑
- 기존 HouseDataService.create()에 위임 → RDB + InfluxDB + WebSocket
- 응답: `"등록 및 알림 처리 완료"` (HTTP 200 OK)

### 2) POST /api/command/fetch
- 디바이스가 자기 SN의 W(Waiting) 명령 폴링
- 호출 시 status W → S(Sent) 자동 전환 (같은 명령 중복 fetch 방지)
- 응답: `[{"SEQ": Long, "CT": String}]`

### 3) 명령 큐 인프라 (B 도메인 사용)
- DeviceCommand 엔티티 (seq/sn/ct/status/createdAt/updatedAt)
- CommandStatus enum (W/S/E)
- `DeviceCommandService.enqueue(sn, ct)` — B 도메인이 Feeder/Waterer/Fan에서 명령 추가 시 호출

## Test plan
- [x] IotDataService — 정상 등록 / SN 누락 / 미등록 시리얼 (3개)
- [x] DeviceCommandService — enqueue / fetch / W→S 전환 / 빈 결과 / 실패 (5개)
- [x] 빌드 성공
- [ ] 통합 환경에서 실제 디바이스 시뮬레이션 (수동)

## 협의 사항
- B 영역(searchSerial/state/result+FCM)은 장훈님 담당
- 명령 큐 enqueue 사용 예시: `deviceCommandService.enqueue(device.serialNum, "FEED")`

🤖 Generated with [Claude Code](https://claude.com/claude-code)