### PR TITLE
[#60] fix: PR #57 후속 안정성 패치

### DIFF
--- a/src/main/java/com/capstone/pethouse/domain/file/controller/FileController.java
+++ b/src/main/java/com/capstone/pethouse/domain/file/controller/FileController.java
@@ -15,7 +15,6 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
-import java.util.Map;
 
 @RequiredArgsConstructor
 @RequestMapping("/file")
@@ -66,11 +65,15 @@ public class FileController {
         }
     }
 
+    /**
+     * 파일 삭제. RFC 9110에서 DELETE body는 허용되나 IoT 디바이스/CDN/프록시 호환성 문제로
+     * query parameter 방식 사용.
+     */
     @DeleteMapping
-    public ResponseEntity<FileResultResponse> delete(@RequestBody Map<String, Object> body) {
+    public ResponseEntity<FileResultResponse> delete(
+            @RequestParam Long seq,
+            @RequestParam(required = false) String deviceId) {
         try {
-            Long seq = Long.valueOf(body.get("seq").toString());
-            String deviceId = body.get("deviceId") != null ? body.get("deviceId").toString() : null;
             fileService.delete(seq, deviceId);
             return ResponseEntity.ok(FileResultResponse.ok("삭제 완료"));
         } catch (Exception e) {

--- a/src/main/java/com/capstone/pethouse/domain/file/service/FileService.java
+++ b/src/main/java/com/capstone/pethouse/domain/file/service/FileService.java
@@ -12,6 +12,8 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
@@ -44,6 +46,11 @@ public class FileService {
         return FileVo.from(file);
     }
 
+    /**
+     * 업로드 흐름:
+     *   1) 디스크 쓰기
+     *   2) DB save (실패 시 catch에서 디스크 파일 삭제 → orphan 방지)
+     */
     @Transactional
     public FileInfo upload(String deviceId, String filename, MultipartFile multipartFile) throws IOException {
         if (deviceId == null || deviceId.isBlank()) {
@@ -53,58 +60,76 @@ public class FileService {
             throw new IllegalArgumentException("file은 필수입니다.");
         }
 
-        String storedFilename = UUID.randomUUID() + "_" + (filename != null ? filename : multipartFile.getOriginalFilename());
-        Path destPath = ensureUploadDir().resolve(storedFilename);
+        String resolvedName = resolveFilename(filename, multipartFile);
+        Path destPath = ensureUploadDir().resolve(UUID.randomUUID() + "_" + resolvedName);
         Files.copy(multipartFile.getInputStream(), destPath, StandardCopyOption.REPLACE_EXISTING);
 
-        FileInfo info = FileInfo.of(
-                deviceId,
-                filename != null ? filename : multipartFile.getOriginalFilename(),
-                destPath.toAbsolutePath().toString(),
-                multipartFile.getContentType(),
-                multipartFile.getSize()
-        );
-        return fileRepository.save(info);
+        try {
+            FileInfo info = FileInfo.of(
+                    deviceId,
+                    resolvedName,
+                    destPath.toAbsolutePath().toString(),
+                    multipartFile.getContentType(),
+                    multipartFile.getSize()
+            );
+            return fileRepository.save(info);
+        } catch (RuntimeException e) {
+            // DB 실패 시 orphan 디스크 파일 즉시 정리
+            tryDelete(destPath);
+            throw e;
+        }
     }
 
+    /**
+     * 수정 흐름:
+     *   1) 새 파일이 있으면 디스크에 먼저 쓰기
+     *   2) 엔티티 업데이트 (영속성 컨텍스트만)
+     *   3) 옛 파일 삭제는 트랜잭션 커밋 후로 지연 → DB 롤백 시 옛 파일 보존
+     *   4) 실패 시 새 파일은 catch에서 정리
+     */
     @Transactional
     public FileInfo updateFile(Long seq, String deviceId, String filename, MultipartFile multipartFile) throws IOException {
         FileInfo file = findOne(seq, deviceId);
 
-        String newPath = file.getFilePath();
-        String newContentType = file.getContentType();
-        Long newSize = file.getFileSize();
-
-        if (multipartFile != null && !multipartFile.isEmpty()) {
-            // 기존 파일 삭제
-            try {
-                Files.deleteIfExists(Paths.get(file.getFilePath()));
-            } catch (IOException e) {
-                log.warn("기존 파일 삭제 실패: {}", file.getFilePath());
-            }
-
-            String storedFilename = UUID.randomUUID() + "_" + (filename != null ? filename : multipartFile.getOriginalFilename());
-            Path destPath = ensureUploadDir().resolve(storedFilename);
-            Files.copy(multipartFile.getInputStream(), destPath, StandardCopyOption.REPLACE_EXISTING);
-
-            newPath = destPath.toAbsolutePath().toString();
-            newContentType = multipartFile.getContentType();
-            newSize = multipartFile.getSize();
+        if (multipartFile == null || multipartFile.isEmpty()) {
+            // 메타데이터만 수정 (파일 그대로)
+            file.update(deviceId, filename, file.getFilePath(), file.getContentType(), file.getFileSize());
+            return file;
         }
 
-        file.update(deviceId, filename, newPath, newContentType, newSize);
-        return file;
+        String oldPath = file.getFilePath();
+        String resolvedName = resolveFilename(filename, multipartFile);
+        Path newPath = ensureUploadDir().resolve(UUID.randomUUID() + "_" + resolvedName);
+        Files.copy(multipartFile.getInputStream(), newPath, StandardCopyOption.REPLACE_EXISTING);
+
+        try {
+            file.update(
+                    deviceId,
+                    resolvedName,
+                    newPath.toAbsolutePath().toString(),
+                    multipartFile.getContentType(),
+                    multipartFile.getSize()
+            );
+            // 옛 파일 삭제는 커밋 후 (롤백되면 옛 파일 보존)
+            registerAfterCommitDeletion(oldPath);
+            return file;
+        } catch (RuntimeException e) {
+            tryDelete(newPath);
+            throw e;
+        }
     }
 
+    /**
+     * 삭제 흐름:
+     *   1) DB 삭제
+     *   2) 디스크 파일 삭제는 커밋 후 (롤백되면 디스크 파일 보존)
+     */
     @Transactional
     public void delete(Long seq, String deviceId) {
         FileInfo file = findOne(seq, deviceId);
-        try {
-            Files.deleteIfExists(Paths.get(file.getFilePath()));
-        } catch (IOException e) {
-            log.warn("파일 삭제 실패: {}", file.getFilePath());
-        }
+        String filePath = file.getFilePath();
         fileRepository.delete(file);
+        registerAfterCommitDeletion(filePath);
     }
 
     @Transactional(readOnly = true)
@@ -142,5 +167,37 @@ public class FileService {
             Files.createDirectories(dir);
         }
         return dir;
+    }
+
+    private String resolveFilename(String filename, MultipartFile multipartFile) {
+        if (filename != null && !filename.isBlank()) return filename;
+        String orig = multipartFile.getOriginalFilename();
+        return (orig != null && !orig.isBlank()) ? orig : "unknown";
+    }
+
+    /**
+     * 트랜잭션 커밋 후 디스크 파일 삭제 등록.
+     * 롤백되면 디스크 파일은 그대로 → 데이터 손실 방지.
+     */
+    private void registerAfterCommitDeletion(String filePath) {
+        if (filePath == null) return;
+        if (TransactionSynchronizationManager.isSynchronizationActive()) {
+            TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+                @Override
+                public void afterCommit() {
+                    tryDelete(Paths.get(filePath));
+                }
+            });
+        } else {
+            tryDelete(Paths.get(filePath));
+        }
+    }
+
+    private void tryDelete(Path path) {
+        try {
+            Files.deleteIfExists(path);
+        } catch (IOException e) {
+            log.warn("파일 삭제 실패: {}", path);
+        }
     }
 }

--- a/src/main/java/com/capstone/pethouse/infra/mqtt/handler/SensorDataHandler.java
+++ b/src/main/java/com/capstone/pethouse/infra/mqtt/handler/SensorDataHandler.java
@@ -51,23 +51,25 @@ public class SensorDataHandler implements MqttMessageHandler {
                 return;
             }
 
+            // 디바이스 타입은 등록된 Device로만 결정. 미등록 디바이스는 reject.
+            Device device = deviceRepository.findByDeviceId(deviceId).orElse(null);
+            if (device == null) {
+                log.warn("Unknown device — deviceId={}, houseId={}, payload dropped", deviceId, houseId);
+                return;
+            }
+
             Double temVal = readDouble(node, "temVal", "tem_val");
             Double coVal = readDouble(node, "coVal", "co_val");
+            String type = device.getDeviceType();
 
-            Device device = deviceRepository.findByDeviceId(deviceId).orElse(null);
-            String type = device != null ? device.getDeviceType() : null;
-
-            // heartVal이 있으면 NECK, 없으면 HOUSE로 추론 (type이 null인 경우)
-            Double heartVal = readDouble(node, "heartVal", "heart_val");
-            Double humVal = readDouble(node, "humVal", "hum_val");
-
-            boolean isNeck = "COLLAR".equalsIgnoreCase(type) || "NECK".equalsIgnoreCase(type)
-                    || (type == null && heartVal != null);
-
-            if (isNeck) {
+            if ("COLLAR".equalsIgnoreCase(type) || "NECK".equalsIgnoreCase(type)) {
+                Double heartVal = readDouble(node, "heartVal", "heart_val");
                 neckDataService.create(new NeckDataRequest(deviceId, temVal, heartVal, coVal));
-            } else {
+            } else if ("HOUSE".equalsIgnoreCase(type)) {
+                Double humVal = readDouble(node, "humVal", "hum_val");
                 houseDataService.create(new HouseDataRequest(deviceId, temVal, humVal, coVal));
+            } else {
+                log.warn("Unsupported deviceType={} — deviceId={}, payload dropped", type, deviceId);
             }
         } catch (Exception e) {
             log.error("Failed to process sensor data — houseId={}, payload={}, error={}",

--- a/src/test/java/com/capstone/pethouse/domain/iot/service/IotDataServiceTest.java
+++ b/src/test/java/com/capstone/pethouse/domain/iot/service/IotDataServiceTest.java
@@ -1,5 +1,6 @@
 package com.capstone.pethouse.domain.iot.service;
 
+import com.capstone.pethouse.domain.User.entity.User;
 import com.capstone.pethouse.domain.device.entity.Device;
 import com.capstone.pethouse.domain.device.repository.DeviceRepository;
 import com.capstone.pethouse.domain.iot.dto.IotDataRequest;
@@ -35,7 +36,8 @@ class IotDataServiceTest {
     private HouseDataService houseDataService;
 
     private Device createDevice() {
-        Device d = Device.of("DEV001", "user01", "SN-001", "HOUSE");
+        User user = User.ofUser("user01", "pw", "홍길동", "010-1111-1111");
+        Device d = Device.of("DEV001", user, "SN-001", "HOUSE");
         ReflectionTestUtils.setField(d, "seq", 1L);
         return d;
     }

--- a/src/test/java/com/capstone/pethouse/domain/sensor/service/ChartServiceTest.java
+++ b/src/test/java/com/capstone/pethouse/domain/sensor/service/ChartServiceTest.java
@@ -1,5 +1,6 @@
 package com.capstone.pethouse.domain.sensor.service;
 
+import com.capstone.pethouse.domain.User.entity.User;
 import com.capstone.pethouse.domain.device.entity.Device;
 import com.capstone.pethouse.domain.device.repository.DeviceRepository;
 import com.capstone.pethouse.domain.sensor.dto.DataVo;
@@ -45,7 +46,8 @@ class ChartServiceTest {
     @Test
     @DisplayName("HOUSE 타입 - 하우스 데이터 반환")
     void chartForHouseDevice() {
-        Device device = Device.of("DEV001", "user01", "SN-001", "HOUSE");
+        User user = User.ofUser("user01", "pw", "홍길동", "010-1111-1111");
+        Device device = Device.of("DEV001", user, "SN-001", "HOUSE");
         ReflectionTestUtils.setField(device, "seq", 1L);
 
         HouseData h = HouseData.of("DEV001", 25.0, 60.0, 400.0);
@@ -67,7 +69,8 @@ class ChartServiceTest {
     @Test
     @DisplayName("COLLAR 타입 - 목걸이 데이터 반환")
     void chartForCollarDevice() {
-        Device device = Device.of("DEV002", "user01", "SN-002", "COLLAR");
+        User user = User.ofUser("user01", "pw", "홍길동", "010-1111-1111");
+        Device device = Device.of("DEV002", user, "SN-002", "COLLAR");
 
         NeckData n = NeckData.of("DEV002", 18.0, 64.0, 404.0);
         ReflectionTestUtils.setField(n, "seq", 1L);


### PR DESCRIPTION
Closes #60

## 수정 항목 4건
1. **FileController.delete** — `@RequestBody Map` → `@RequestParam` (NPE 가드 + HTTP 표준)
2. **FileService.upload** — DB save 실패 시 디스크 orphan 정리
3. **FileService.updateFile/delete** — 옛 파일 삭제를 트랜잭션 커밋 후로 지연 (롤백 시 데이터 보존)
4. **SensorDataHandler** — 미등록/지원 안 되는 deviceType은 reject + 경고 로그

## 부가
- `resolveFilename` 헬퍼 추가 (filename + originalFilename + "unknown" fallback)
- `TransactionSynchronizationManager.registerSynchronization`로 afterCommit 디스크 정리

## Test plan
- [x] 기존 테스트 모두 통과 (33개)
- [x] 빌드 성공
- [ ] 통합 환경에서 강제 DB 실패 시뮬레이션으로 orphan 검증 (수동)

🤖 Generated with [Claude Code](https://claude.com/claude-code)